### PR TITLE
fix: call `try` to retrieve tgw_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   for_each = var.vpc_attachments
 
-  transit_gateway_id = lookup(each.value, "tgw_id", aws_ec2_transit_gateway.this[0].id)
+  transit_gateway_id = lookup(each.value, "tgw_id", try(aws_ec2_transit_gateway.this[0].id, null))
   vpc_id             = each.value["vpc_id"]
   subnet_ids         = each.value["subnet_ids"]
 


### PR DESCRIPTION
## Description
Aims to fix #11, where attaching VPCs but not creating the TGW will fail.
Check for tgw_id on line 70 using terraform's `try` function so that the `lookup`'s default doesn't break it.

## Motivation and Context
See #11 

## Breaking Changes
Nope

## How Has This Been Tested?
Tested on my environment with and without creating TGW, it works for me.
