### PR TITLE
fix: fix variable in aws_ec2_transit_gateway_route_table_propagation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 locals {
   vpc_attachments_without_default_route_table_association = {
-    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_association", true) == true
+    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_association", true) != true
   }
 
   vpc_attachments_without_default_route_table_propagation = {
-    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_propagation", true) == true
+    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_propagation", true) != true
   }
 
   // List of maps with key and route values

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "this" {
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
-  for_each = local.vpc_attachments_without_default_route_table_association
+  for_each = local.vpc_attachments_without_default_route_table_propagation
 
   // Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 locals {
   vpc_attachments_without_default_route_table_association = {
-    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_association", true) != true
+    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_association", true) == true
   }
 
   vpc_attachments_without_default_route_table_propagation = {
-    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_propagation", true) != true
+    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_propagation", true) == true
   }
 
   // List of maps with key and route values


### PR DESCRIPTION
## Description
fixed the variable, there is a unique local declared but not in use.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
