### PR TITLE
improvement: Changing a count to for_each so reordering principals does not cause recreation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,6 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  #count = var.create_tgw && var.share_tgw ? length(var.ram_principals) : 0
   for_each = toset(var.ram_principals)
   principal          = each.value
   resource_share_arn = aws_ram_resource_share.this[0].arn

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  for_each = toset(var.ram_principals)
+  for_each           = toset(var.ram_principals)
   principal          = each.value
   resource_share_arn = aws_ram_resource_share.this[0].arn
 }

--- a/main.tf
+++ b/main.tf
@@ -127,8 +127,8 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  count = var.create_tgw && var.share_tgw ? length(var.ram_principals) : 0
-
-  principal          = var.ram_principals[count.index]
+  #count = var.create_tgw && var.share_tgw ? length(var.ram_principals) : 0
+  for_each = toset(var.ram_principals)
+  principal          = each.value
   resource_share_arn = aws_ram_resource_share.this[0].arn
 }

--- a/output.tf
+++ b/output.tf
@@ -88,5 +88,6 @@ output "this_ram_resource_share_id" {
 // aws_ram_principal_association
 output "this_ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
-  value       = element(concat(aws_ram_principal_association.this.*.id, [""]), 0)
+  value       = [ for k, v in aws_ram_principal_association.this : v.id ]
+
 }

--- a/output.tf
+++ b/output.tf
@@ -88,6 +88,6 @@ output "this_ram_resource_share_id" {
 // aws_ram_principal_association
 output "this_ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
-  value       = [ for k, v in aws_ram_principal_association.this : v.id ]
+  value       = [for k, v in aws_ram_principal_association.this : v.id]
 
 }


### PR DESCRIPTION
## Description
Changing a count to for_each so reordering principals does not cause recreation
<!--- Describe your changes in detail -->

## Motivation and Context
Because with count changing the order recreates all of the following (the change) objects
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
