### PR TITLE
docs: typos on example readme.mds

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -4,7 +4,7 @@ Configuration in this directory creates AWS Transit Gateway, attach VPC to it an
 
 ## Notes
 
-There is a famous limitation in Terraform which prevents us from using computed values in `count`. Fot this reason this example is using data-sources to discover already created default VPC and subnets.
+There is a famous limitation in Terraform which prevents us from using computed values in `count`. For this reason this example is using data-sources to discover already created default VPC and subnets.
 
 In real-world scenario you will have to split creation of VPC (using [terraform-aws-vpc modules](https://github.com/terraform-aws-modules/terraform-aws-vpc)) and creation of TGW resources using this module. 
 

--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -4,7 +4,7 @@ Configuration in this directory creates AWS Transit Gateway, attach VPC to it an
 
 ## Notes
 
-There is a famous limitation in Terraform which prevents us from using computed values in `count`. Fot this reason this example is using data-sources to discover already created default VPC and subnets.
+There is a famous limitation in Terraform which prevents us from using computed values in `count`. For this reason this example is using data-sources to discover already created default VPC and subnets.
 
 In real-world scenario you will have to split creation of VPC (using [terraform-aws-vpc modules](https://github.com/terraform-aws-modules/terraform-aws-vpc)) and creation of TGW resources using this module. 
 


### PR DESCRIPTION
## Description
Fixing typos in the example README.md-s

## Motivation and Context
I noticed some typos

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No

## How Has This Been Tested?
Docs typo change only, no real testing needed.
