### PR TITLE
improvement: Only create a route_table when there are vpc_attachments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_ec2_transit_gateway" "this" {
 # Route table and routes
 #########################
 resource "aws_ec2_transit_gateway_route_table" "this" {
-  count = var.create_tgw ? 1 : 0
+  count = var.create_tgw && length(var.vpc_attachments) > 0 ? 1 : 0
 
   transit_gateway_id = aws_ec2_transit_gateway.this[0].id
 


### PR DESCRIPTION
## Description

Considering someone might not want to attach any VPC using the module, but attach it separately on each account, the module should avoid creating a route table that will stay unused.

For example, this code:

```
module "transit_gateway" {
  source  = "terraform-aws-modules/transit-gateway/aws"
  version = "~> 1.0"

  name        = "shared-services"
  description = "Transit Gateway shared with several other AWS accounts"

  enable_auto_accept_shared_attachments  = true
  enable_default_route_table_association = false
  enable_default_route_table_propagation = false

  ram_principals = var.ram_principals
}
```

Should not need a `route_table` named `shared-services` to be created.

References to `aws_ec2_transit_gateway_route_table` are always used inside for loops that need `vpc_attachments` to have items.

## Motivation and Context

To avoid a empty resource that is not used.

## Breaking Changes

This could potentially remove the route after a module upgrade, but only if there are no `vpc_attachments`, and that is fine, as the module does not use it anywhere.

## How Has This Been Tested?

Code has been applied and tested on local env.
