### PR TITLE
feat: Add tags for default TGW Route Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ module "vpc" {
 | share\_tgw | Whether to share your transit gateway with other accounts | `bool` | `true` | no |
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | tgw\_route\_table\_tags | Additional tags for the TGW route table | `map(string)` | `{}` | no |
+| tgw\_default\_route\_table\_tags | Additional tags for the Default TGW route table | `map(string)` | `{}` | no |
 | tgw\_tags | Additional tags for the TGW | `map(string)` | `{}` | no |
 | tgw\_vpc\_attachment\_tags | Additional tags for VPC attachments | `map(string)` | `{}` | no |
 | transit\_gateway\_route\_table\_id | Identifier of EC2 Transit Gateway Route Table to use with the Target Gateway when reusing it between multiple TGWs | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,14 @@ resource "aws_ec2_transit_gateway" "this" {
   )
 }
 
+resource "aws_ec2_tag" "this" {
+  count = var.create_tgw ? length(var.tgw_default_route_table_tags) : 0
+
+  resource_id = aws_ec2_transit_gateway.this[0].association_default_route_table_id
+  key         = keys(var.tgw_default_route_table_tags)[count.index]
+  value       = values(var.tgw_default_route_table_tags)[count.index]
+}
+
 #########################
 # Route table and routes
 #########################

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,12 @@ variable "tgw_route_table_tags" {
   default     = {}
 }
 
+variable "tgw_default_route_table_tags" {
+  description = "Additional tags for the Default TGW route table"
+  type        = map(string)
+  default     = {}
+}
+
 variable "tgw_vpc_attachment_tags" {
   description = "Additional tags for VPC attachments"
   type        = map(string)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add tags to the default transit gateway route table that gets automatically created with the TGW

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/23

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
It will add tags to the default TGW Route Table, it shouldn't break anything.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in own environment
