### PR TITLE
feat: Optionally update VPC Route Tables for attached VPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ No modules.
 | [aws_ram_resource_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_association) | resource |
 | [aws_ram_resource_share.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share) | resource |
 | [aws_ram_resource_share_accepter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share_accepter) | resource |
+| [aws_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ locals {
     var.tags,
     var.tgw_default_route_table_tags,
   )
+
   vpc_route_table_destination_cidr = flatten([
     for k, v in var.vpc_attachments : [
       for rtb_id in lookup(v, "vpc_route_table_ids", []) : {

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ locals {
     ]
   ])
 }
+#
 
 resource "aws_ec2_transit_gateway" "this" {
   count = var.create_tgw ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,14 @@ locals {
     var.tags,
     var.tgw_default_route_table_tags,
   )
+  vpc_route_table_destination_cidr = flatten([
+    for k, v in var.vpc_attachments : [
+      for rtb_id in lookup(v, "vpc_route_table_ids", []) : {
+        rtb_id = rtb_id
+        cidr   = v["tgw_destination_cidr"]
+      }
+    ]
+  ])
 }
 
 resource "aws_ec2_transit_gateway" "this" {
@@ -74,6 +82,14 @@ resource "aws_ec2_transit_gateway_route" "this" {
 
   transit_gateway_route_table_id = var.create_tgw ? aws_ec2_transit_gateway_route_table.this[0].id : var.transit_gateway_route_table_id
   transit_gateway_attachment_id  = tobool(lookup(local.vpc_attachments_with_routes[count.index][1], "blackhole", false)) == false ? aws_ec2_transit_gateway_vpc_attachment.this[local.vpc_attachments_with_routes[count.index][0]["key"]].id : null
+}
+
+resource "aws_route" "this" {
+  for_each = { for x in local.vpc_route_table_destination_cidr : x.rtb_id => x.cidr }
+
+  route_table_id         = each.key
+  destination_cidr_block = each.value
+  transit_gateway_id     = aws_ec2_transit_gateway.this[0].id
 }
 
 ###########################################################

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,6 @@ locals {
     ]
   ])
 }
-#
 
 resource "aws_ec2_transit_gateway" "this" {
   count = var.create_tgw ? 1 : 0


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When attaching a VPC to a Transit Gateway, you also need to update the VPC's Route Table(s) to direct traffic to the TGW. Currently this needs to be done outside of the module. With this change it is now possible to provide 2 extra values on the `vpc_attachments` object.

For example:
```
vpc_attachments = {
  some_vpc = {
    ... other values

    # optional new values
    vpc_route_table_ids  = module.some_vpc.private_route_table_ids # using https://github.com/terraform-aws-modules/terraform-aws-vpc
    tgw_destination_cidr = "0.0.0.0/0"
  }
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Motivation: currently we are using this module and additionally defining our routes outside the module.
There's also this issue open: https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/17

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
If you have defined routes outside the module you cannot redefine them with these new parameters (you need to move them with `terraform state mv` or delete and recreate them).
Since the new parameters are optional there is no breaking change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In own environment, with and without the new values.
