### PR TITLE
fix: bump min supported version due to types unsupported on current

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module "vpc" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.24 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,7 +25,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.24 |
 
 ## Providers

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 2.24"

--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -25,7 +25,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.7 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.24 |
 
 ## Providers

--- a/examples/multi-account/versions.tf
+++ b/examples/multi-account/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 2.24"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.7"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 2.24"


### PR DESCRIPTION
## Description
- bump min supported version due to types unsupported on current

## Motivation and Context
- get static checks back to passing state

## Breaking Changes
- no

## How Has This Been Tested?
- ci-cd static checks