### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.47.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -85,81 +85,81 @@ module "vpc" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.24 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.24 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.24 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_ec2_transit_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway) |
-| [aws_ec2_transit_gateway_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) |
-| [aws_ec2_transit_gateway_route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table) |
-| [aws_ec2_transit_gateway_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) |
-| [aws_ec2_transit_gateway_route_table_propagation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_propagation) |
-| [aws_ec2_transit_gateway_vpc_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment) |
-| [aws_ram_principal_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_principal_association) |
-| [aws_ram_resource_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_association) |
-| [aws_ram_resource_share](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share) |
-| [aws_ram_resource_share_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share_accepter) |
+| Name | Type |
+|------|------|
+| [aws_ec2_transit_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway) | resource |
+| [aws_ec2_transit_gateway_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
+| [aws_ec2_transit_gateway_route_table.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table) | resource |
+| [aws_ec2_transit_gateway_route_table_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
+| [aws_ec2_transit_gateway_route_table_propagation.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_propagation) | resource |
+| [aws_ec2_transit_gateway_vpc_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment) | resource |
+| [aws_ram_principal_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_principal_association) | resource |
+| [aws_ram_resource_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_association) | resource |
+| [aws_ram_resource_share.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share) | resource |
+| [aws_ram_resource_share_accepter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share_accepter) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| amazon\_side\_asn | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the TGW is created with the current default Amazon ASN. | `string` | `"64512"` | no |
-| create\_tgw | Controls if TGW should be created (it affects almost all resources) | `bool` | `true` | no |
-| description | Description of the EC2 Transit Gateway | `string` | `null` | no |
-| enable\_auto\_accept\_shared\_attachments | Whether resource attachment requests are automatically accepted | `bool` | `false` | no |
-| enable\_default\_route\_table\_association | Whether resource attachments are automatically associated with the default association route table | `bool` | `true` | no |
-| enable\_default\_route\_table\_propagation | Whether resource attachments automatically propagate routes to the default propagation route table | `bool` | `true` | no |
-| enable\_dns\_support | Should be true to enable DNS support in the TGW | `bool` | `true` | no |
-| enable\_vpn\_ecmp\_support | Whether VPN Equal Cost Multipath Protocol support is enabled | `bool` | `true` | no |
-| name | Name to be used on all the resources as identifier | `string` | `""` | no |
-| ram\_allow\_external\_principals | Indicates whether principals outside your organization can be associated with a resource share. | `bool` | `false` | no |
-| ram\_name | The name of the resource share of TGW | `string` | `""` | no |
-| ram\_principals | A list of principals to share TGW with. Possible values are an AWS account ID, an AWS Organizations Organization ARN, or an AWS Organizations Organization Unit ARN | `list(string)` | `[]` | no |
-| ram\_resource\_share\_arn | ARN of RAM resource share | `string` | `""` | no |
-| ram\_tags | Additional tags for the RAM | `map(string)` | `{}` | no |
-| share\_tgw | Whether to share your transit gateway with other accounts | `bool` | `true` | no |
-| tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
-| tgw\_route\_table\_tags | Additional tags for the TGW route table | `map(string)` | `{}` | no |
-| tgw\_tags | Additional tags for the TGW | `map(string)` | `{}` | no |
-| tgw\_vpc\_attachment\_tags | Additional tags for VPC attachments | `map(string)` | `{}` | no |
-| transit\_gateway\_route\_table\_id | Identifier of EC2 Transit Gateway Route Table to use with the Target Gateway when reusing it between multiple TGWs | `string` | `null` | no |
-| vpc\_attachments | Maps of maps of VPC details to attach to TGW. Type 'any' to disable type validation by Terraform. | `any` | `{}` | no |
+| <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the TGW is created with the current default Amazon ASN. | `string` | `"64512"` | no |
+| <a name="input_create_tgw"></a> [create\_tgw](#input\_create\_tgw) | Controls if TGW should be created (it affects almost all resources) | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | Description of the EC2 Transit Gateway | `string` | `null` | no |
+| <a name="input_enable_auto_accept_shared_attachments"></a> [enable\_auto\_accept\_shared\_attachments](#input\_enable\_auto\_accept\_shared\_attachments) | Whether resource attachment requests are automatically accepted | `bool` | `false` | no |
+| <a name="input_enable_default_route_table_association"></a> [enable\_default\_route\_table\_association](#input\_enable\_default\_route\_table\_association) | Whether resource attachments are automatically associated with the default association route table | `bool` | `true` | no |
+| <a name="input_enable_default_route_table_propagation"></a> [enable\_default\_route\_table\_propagation](#input\_enable\_default\_route\_table\_propagation) | Whether resource attachments automatically propagate routes to the default propagation route table | `bool` | `true` | no |
+| <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | Should be true to enable DNS support in the TGW | `bool` | `true` | no |
+| <a name="input_enable_vpn_ecmp_support"></a> [enable\_vpn\_ecmp\_support](#input\_enable\_vpn\_ecmp\_support) | Whether VPN Equal Cost Multipath Protocol support is enabled | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier | `string` | `""` | no |
+| <a name="input_ram_allow_external_principals"></a> [ram\_allow\_external\_principals](#input\_ram\_allow\_external\_principals) | Indicates whether principals outside your organization can be associated with a resource share. | `bool` | `false` | no |
+| <a name="input_ram_name"></a> [ram\_name](#input\_ram\_name) | The name of the resource share of TGW | `string` | `""` | no |
+| <a name="input_ram_principals"></a> [ram\_principals](#input\_ram\_principals) | A list of principals to share TGW with. Possible values are an AWS account ID, an AWS Organizations Organization ARN, or an AWS Organizations Organization Unit ARN | `list(string)` | `[]` | no |
+| <a name="input_ram_resource_share_arn"></a> [ram\_resource\_share\_arn](#input\_ram\_resource\_share\_arn) | ARN of RAM resource share | `string` | `""` | no |
+| <a name="input_ram_tags"></a> [ram\_tags](#input\_ram\_tags) | Additional tags for the RAM | `map(string)` | `{}` | no |
+| <a name="input_share_tgw"></a> [share\_tgw](#input\_share\_tgw) | Whether to share your transit gateway with other accounts | `bool` | `true` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_tgw_route_table_tags"></a> [tgw\_route\_table\_tags](#input\_tgw\_route\_table\_tags) | Additional tags for the TGW route table | `map(string)` | `{}` | no |
+| <a name="input_tgw_tags"></a> [tgw\_tags](#input\_tgw\_tags) | Additional tags for the TGW | `map(string)` | `{}` | no |
+| <a name="input_tgw_vpc_attachment_tags"></a> [tgw\_vpc\_attachment\_tags](#input\_tgw\_vpc\_attachment\_tags) | Additional tags for VPC attachments | `map(string)` | `{}` | no |
+| <a name="input_transit_gateway_route_table_id"></a> [transit\_gateway\_route\_table\_id](#input\_transit\_gateway\_route\_table\_id) | Identifier of EC2 Transit Gateway Route Table to use with the Target Gateway when reusing it between multiple TGWs | `string` | `null` | no |
+| <a name="input_vpc_attachments"></a> [vpc\_attachments](#input\_vpc\_attachments) | Maps of maps of VPC details to attach to TGW. Type 'any' to disable type validation by Terraform. | `any` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_ec2\_transit\_gateway\_arn | EC2 Transit Gateway Amazon Resource Name (ARN) |
-| this\_ec2\_transit\_gateway\_association\_default\_route\_table\_id | Identifier of the default association route table |
-| this\_ec2\_transit\_gateway\_id | EC2 Transit Gateway identifier |
-| this\_ec2\_transit\_gateway\_owner\_id | Identifier of the AWS account that owns the EC2 Transit Gateway |
-| this\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id | Identifier of the default propagation route table |
-| this\_ec2\_transit\_gateway\_route\_ids | List of EC2 Transit Gateway Route Table identifier combined with destination |
-| this\_ec2\_transit\_gateway\_route\_table\_association | Map of EC2 Transit Gateway Route Table Association attributes |
-| this\_ec2\_transit\_gateway\_route\_table\_association\_ids | List of EC2 Transit Gateway Route Table Association identifiers |
-| this\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table | Boolean whether this is the default association route table for the EC2 Transit Gateway |
-| this\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
-| this\_ec2\_transit\_gateway\_route\_table\_id | EC2 Transit Gateway Route Table identifier |
-| this\_ec2\_transit\_gateway\_route\_table\_propagation | Map of EC2 Transit Gateway Route Table Propagation attributes |
-| this\_ec2\_transit\_gateway\_route\_table\_propagation\_ids | List of EC2 Transit Gateway Route Table Propagation identifiers |
-| this\_ec2\_transit\_gateway\_vpc\_attachment | Map of EC2 Transit Gateway VPC Attachment attributes |
-| this\_ec2\_transit\_gateway\_vpc\_attachment\_ids | List of EC2 Transit Gateway VPC Attachment identifiers |
-| this\_ram\_principal\_association\_id | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
-| this\_ram\_resource\_share\_id | The Amazon Resource Name (ARN) of the resource share |
+| <a name="output_this_ec2_transit_gateway_arn"></a> [this\_ec2\_transit\_gateway\_arn](#output\_this\_ec2\_transit\_gateway\_arn) | EC2 Transit Gateway Amazon Resource Name (ARN) |
+| <a name="output_this_ec2_transit_gateway_association_default_route_table_id"></a> [this\_ec2\_transit\_gateway\_association\_default\_route\_table\_id](#output\_this\_ec2\_transit\_gateway\_association\_default\_route\_table\_id) | Identifier of the default association route table |
+| <a name="output_this_ec2_transit_gateway_id"></a> [this\_ec2\_transit\_gateway\_id](#output\_this\_ec2\_transit\_gateway\_id) | EC2 Transit Gateway identifier |
+| <a name="output_this_ec2_transit_gateway_owner_id"></a> [this\_ec2\_transit\_gateway\_owner\_id](#output\_this\_ec2\_transit\_gateway\_owner\_id) | Identifier of the AWS account that owns the EC2 Transit Gateway |
+| <a name="output_this_ec2_transit_gateway_propagation_default_route_table_id"></a> [this\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id](#output\_this\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id) | Identifier of the default propagation route table |
+| <a name="output_this_ec2_transit_gateway_route_ids"></a> [this\_ec2\_transit\_gateway\_route\_ids](#output\_this\_ec2\_transit\_gateway\_route\_ids) | List of EC2 Transit Gateway Route Table identifier combined with destination |
+| <a name="output_this_ec2_transit_gateway_route_table_association"></a> [this\_ec2\_transit\_gateway\_route\_table\_association](#output\_this\_ec2\_transit\_gateway\_route\_table\_association) | Map of EC2 Transit Gateway Route Table Association attributes |
+| <a name="output_this_ec2_transit_gateway_route_table_association_ids"></a> [this\_ec2\_transit\_gateway\_route\_table\_association\_ids](#output\_this\_ec2\_transit\_gateway\_route\_table\_association\_ids) | List of EC2 Transit Gateway Route Table Association identifiers |
+| <a name="output_this_ec2_transit_gateway_route_table_default_association_route_table"></a> [this\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table](#output\_this\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table) | Boolean whether this is the default association route table for the EC2 Transit Gateway |
+| <a name="output_this_ec2_transit_gateway_route_table_default_propagation_route_table"></a> [this\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table](#output\_this\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table) | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
+| <a name="output_this_ec2_transit_gateway_route_table_id"></a> [this\_ec2\_transit\_gateway\_route\_table\_id](#output\_this\_ec2\_transit\_gateway\_route\_table\_id) | EC2 Transit Gateway Route Table identifier |
+| <a name="output_this_ec2_transit_gateway_route_table_propagation"></a> [this\_ec2\_transit\_gateway\_route\_table\_propagation](#output\_this\_ec2\_transit\_gateway\_route\_table\_propagation) | Map of EC2 Transit Gateway Route Table Propagation attributes |
+| <a name="output_this_ec2_transit_gateway_route_table_propagation_ids"></a> [this\_ec2\_transit\_gateway\_route\_table\_propagation\_ids](#output\_this\_ec2\_transit\_gateway\_route\_table\_propagation\_ids) | List of EC2 Transit Gateway Route Table Propagation identifiers |
+| <a name="output_this_ec2_transit_gateway_vpc_attachment"></a> [this\_ec2\_transit\_gateway\_vpc\_attachment](#output\_this\_ec2\_transit\_gateway\_vpc\_attachment) | Map of EC2 Transit Gateway VPC Attachment attributes |
+| <a name="output_this_ec2_transit_gateway_vpc_attachment_ids"></a> [this\_ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_this\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
+| <a name="output_this_ram_principal_association_id"></a> [this\_ram\_principal\_association\_id](#output\_this\_ram\_principal\_association\_id) | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
+| <a name="output_this_ram_resource_share_id"></a> [this\_ram\_resource\_share\_id](#output\_this\_ram\_resource\_share\_id) | The Amazon Resource Name (ARN) of the resource share |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,53 +25,53 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.24 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.24 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.24 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| tgw | ../../ |  |
-| vpc1 | terraform-aws-modules/vpc/aws | ~> 2.0 |
-| vpc2 | terraform-aws-modules/vpc/aws | ~> 2.0 |
+| <a name="module_tgw"></a> [tgw](#module\_tgw) | ../../ |  |
+| <a name="module_vpc1"></a> [vpc1](#module\_vpc1) | terraform-aws-modules/vpc/aws | ~> 2.0 |
+| <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | ~> 2.0 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+| Name | Type |
+|------|------|
+| [aws_subnet_ids.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_ec2\_transit\_gateway\_arn | EC2 Transit Gateway Amazon Resource Name (ARN) |
-| this\_ec2\_transit\_gateway\_association\_default\_route\_table\_id | Identifier of the default association route table |
-| this\_ec2\_transit\_gateway\_id | EC2 Transit Gateway identifier |
-| this\_ec2\_transit\_gateway\_owner\_id | Identifier of the AWS account that owns the EC2 Transit Gateway |
-| this\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id | Identifier of the default propagation route table |
-| this\_ec2\_transit\_gateway\_route\_ids | List of EC2 Transit Gateway Route Table identifier combined with destination |
-| this\_ec2\_transit\_gateway\_route\_table\_association | Map of EC2 Transit Gateway Route Table Association attributes |
-| this\_ec2\_transit\_gateway\_route\_table\_association\_ids | List of EC2 Transit Gateway Route Table Association identifiers |
-| this\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table | Boolean whether this is the default association route table for the EC2 Transit Gateway |
-| this\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
-| this\_ec2\_transit\_gateway\_route\_table\_id | EC2 Transit Gateway Route Table identifier |
-| this\_ec2\_transit\_gateway\_route\_table\_propagation | Map of EC2 Transit Gateway Route Table Propagation attributes |
-| this\_ec2\_transit\_gateway\_route\_table\_propagation\_ids | List of EC2 Transit Gateway Route Table Propagation identifiers |
-| this\_ec2\_transit\_gateway\_vpc\_attachment | Map of EC2 Transit Gateway VPC Attachment attributes |
-| this\_ec2\_transit\_gateway\_vpc\_attachment\_ids | List of EC2 Transit Gateway VPC Attachment identifiers |
-| this\_ram\_principal\_association\_id | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
-| this\_ram\_resource\_share\_id | The Amazon Resource Name (ARN) of the resource share |
+| <a name="output_this_ec2_transit_gateway_arn"></a> [this\_ec2\_transit\_gateway\_arn](#output\_this\_ec2\_transit\_gateway\_arn) | EC2 Transit Gateway Amazon Resource Name (ARN) |
+| <a name="output_this_ec2_transit_gateway_association_default_route_table_id"></a> [this\_ec2\_transit\_gateway\_association\_default\_route\_table\_id](#output\_this\_ec2\_transit\_gateway\_association\_default\_route\_table\_id) | Identifier of the default association route table |
+| <a name="output_this_ec2_transit_gateway_id"></a> [this\_ec2\_transit\_gateway\_id](#output\_this\_ec2\_transit\_gateway\_id) | EC2 Transit Gateway identifier |
+| <a name="output_this_ec2_transit_gateway_owner_id"></a> [this\_ec2\_transit\_gateway\_owner\_id](#output\_this\_ec2\_transit\_gateway\_owner\_id) | Identifier of the AWS account that owns the EC2 Transit Gateway |
+| <a name="output_this_ec2_transit_gateway_propagation_default_route_table_id"></a> [this\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id](#output\_this\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id) | Identifier of the default propagation route table |
+| <a name="output_this_ec2_transit_gateway_route_ids"></a> [this\_ec2\_transit\_gateway\_route\_ids](#output\_this\_ec2\_transit\_gateway\_route\_ids) | List of EC2 Transit Gateway Route Table identifier combined with destination |
+| <a name="output_this_ec2_transit_gateway_route_table_association"></a> [this\_ec2\_transit\_gateway\_route\_table\_association](#output\_this\_ec2\_transit\_gateway\_route\_table\_association) | Map of EC2 Transit Gateway Route Table Association attributes |
+| <a name="output_this_ec2_transit_gateway_route_table_association_ids"></a> [this\_ec2\_transit\_gateway\_route\_table\_association\_ids](#output\_this\_ec2\_transit\_gateway\_route\_table\_association\_ids) | List of EC2 Transit Gateway Route Table Association identifiers |
+| <a name="output_this_ec2_transit_gateway_route_table_default_association_route_table"></a> [this\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table](#output\_this\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table) | Boolean whether this is the default association route table for the EC2 Transit Gateway |
+| <a name="output_this_ec2_transit_gateway_route_table_default_propagation_route_table"></a> [this\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table](#output\_this\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table) | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
+| <a name="output_this_ec2_transit_gateway_route_table_id"></a> [this\_ec2\_transit\_gateway\_route\_table\_id](#output\_this\_ec2\_transit\_gateway\_route\_table\_id) | EC2 Transit Gateway Route Table identifier |
+| <a name="output_this_ec2_transit_gateway_route_table_propagation"></a> [this\_ec2\_transit\_gateway\_route\_table\_propagation](#output\_this\_ec2\_transit\_gateway\_route\_table\_propagation) | Map of EC2 Transit Gateway Route Table Propagation attributes |
+| <a name="output_this_ec2_transit_gateway_route_table_propagation_ids"></a> [this\_ec2\_transit\_gateway\_route\_table\_propagation\_ids](#output\_this\_ec2\_transit\_gateway\_route\_table\_propagation\_ids) | List of EC2 Transit Gateway Route Table Propagation identifiers |
+| <a name="output_this_ec2_transit_gateway_vpc_attachment"></a> [this\_ec2\_transit\_gateway\_vpc\_attachment](#output\_this\_ec2\_transit\_gateway\_vpc\_attachment) | Map of EC2 Transit Gateway VPC Attachment attributes |
+| <a name="output_this_ec2_transit_gateway_vpc_attachment_ids"></a> [this\_ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_this\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
+| <a name="output_this_ram_principal_association_id"></a> [this\_ram\_principal\_association\_id](#output\_this\_ram\_principal\_association\_id) | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
+| <a name="output_this_ram_resource_share_id"></a> [this\_ram\_resource\_share\_id](#output\_this\_ram\_resource\_share\_id) | The Amazon Resource Name (ARN) of the resource share |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -25,53 +25,53 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.24 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.24 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.24 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| tgw | ../../ |  |
-| tgw_peer | ../../ |  |
-| vpc1 | terraform-aws-modules/vpc/aws | ~> 2.0 |
+| <a name="module_tgw"></a> [tgw](#module\_tgw) | ../../ |  |
+| <a name="module_tgw_peer"></a> [tgw\_peer](#module\_tgw\_peer) | ../../ |  |
+| <a name="module_vpc1"></a> [vpc1](#module\_vpc1) | terraform-aws-modules/vpc/aws | ~> 2.0 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+| Name | Type |
+|------|------|
+| [aws_subnet_ids.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_ec2\_transit\_gateway\_arn | EC2 Transit Gateway Amazon Resource Name (ARN) |
-| this\_ec2\_transit\_gateway\_association\_default\_route\_table\_id | Identifier of the default association route table |
-| this\_ec2\_transit\_gateway\_id | EC2 Transit Gateway identifier |
-| this\_ec2\_transit\_gateway\_owner\_id | Identifier of the AWS account that owns the EC2 Transit Gateway |
-| this\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id | Identifier of the default propagation route table |
-| this\_ec2\_transit\_gateway\_route\_ids | List of EC2 Transit Gateway Route Table identifier combined with destination |
-| this\_ec2\_transit\_gateway\_route\_table\_association | Map of EC2 Transit Gateway Route Table Association attributes |
-| this\_ec2\_transit\_gateway\_route\_table\_association\_ids | List of EC2 Transit Gateway Route Table Association identifiers |
-| this\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table | Boolean whether this is the default association route table for the EC2 Transit Gateway |
-| this\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
-| this\_ec2\_transit\_gateway\_route\_table\_id | EC2 Transit Gateway Route Table identifier |
-| this\_ec2\_transit\_gateway\_route\_table\_propagation | Map of EC2 Transit Gateway Route Table Propagation attributes |
-| this\_ec2\_transit\_gateway\_route\_table\_propagation\_ids | List of EC2 Transit Gateway Route Table Propagation identifiers |
-| this\_ec2\_transit\_gateway\_vpc\_attachment | Map of EC2 Transit Gateway VPC Attachment attributes |
-| this\_ec2\_transit\_gateway\_vpc\_attachment\_ids | List of EC2 Transit Gateway VPC Attachment identifiers |
-| this\_ram\_principal\_association\_id | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
-| this\_ram\_resource\_share\_id | The Amazon Resource Name (ARN) of the resource share |
+| <a name="output_this_ec2_transit_gateway_arn"></a> [this\_ec2\_transit\_gateway\_arn](#output\_this\_ec2\_transit\_gateway\_arn) | EC2 Transit Gateway Amazon Resource Name (ARN) |
+| <a name="output_this_ec2_transit_gateway_association_default_route_table_id"></a> [this\_ec2\_transit\_gateway\_association\_default\_route\_table\_id](#output\_this\_ec2\_transit\_gateway\_association\_default\_route\_table\_id) | Identifier of the default association route table |
+| <a name="output_this_ec2_transit_gateway_id"></a> [this\_ec2\_transit\_gateway\_id](#output\_this\_ec2\_transit\_gateway\_id) | EC2 Transit Gateway identifier |
+| <a name="output_this_ec2_transit_gateway_owner_id"></a> [this\_ec2\_transit\_gateway\_owner\_id](#output\_this\_ec2\_transit\_gateway\_owner\_id) | Identifier of the AWS account that owns the EC2 Transit Gateway |
+| <a name="output_this_ec2_transit_gateway_propagation_default_route_table_id"></a> [this\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id](#output\_this\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id) | Identifier of the default propagation route table |
+| <a name="output_this_ec2_transit_gateway_route_ids"></a> [this\_ec2\_transit\_gateway\_route\_ids](#output\_this\_ec2\_transit\_gateway\_route\_ids) | List of EC2 Transit Gateway Route Table identifier combined with destination |
+| <a name="output_this_ec2_transit_gateway_route_table_association"></a> [this\_ec2\_transit\_gateway\_route\_table\_association](#output\_this\_ec2\_transit\_gateway\_route\_table\_association) | Map of EC2 Transit Gateway Route Table Association attributes |
+| <a name="output_this_ec2_transit_gateway_route_table_association_ids"></a> [this\_ec2\_transit\_gateway\_route\_table\_association\_ids](#output\_this\_ec2\_transit\_gateway\_route\_table\_association\_ids) | List of EC2 Transit Gateway Route Table Association identifiers |
+| <a name="output_this_ec2_transit_gateway_route_table_default_association_route_table"></a> [this\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table](#output\_this\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table) | Boolean whether this is the default association route table for the EC2 Transit Gateway |
+| <a name="output_this_ec2_transit_gateway_route_table_default_propagation_route_table"></a> [this\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table](#output\_this\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table) | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
+| <a name="output_this_ec2_transit_gateway_route_table_id"></a> [this\_ec2\_transit\_gateway\_route\_table\_id](#output\_this\_ec2\_transit\_gateway\_route\_table\_id) | EC2 Transit Gateway Route Table identifier |
+| <a name="output_this_ec2_transit_gateway_route_table_propagation"></a> [this\_ec2\_transit\_gateway\_route\_table\_propagation](#output\_this\_ec2\_transit\_gateway\_route\_table\_propagation) | Map of EC2 Transit Gateway Route Table Propagation attributes |
+| <a name="output_this_ec2_transit_gateway_route_table_propagation_ids"></a> [this\_ec2\_transit\_gateway\_route\_table\_propagation\_ids](#output\_this\_ec2\_transit\_gateway\_route\_table\_propagation\_ids) | List of EC2 Transit Gateway Route Table Propagation identifiers |
+| <a name="output_this_ec2_transit_gateway_vpc_attachment"></a> [this\_ec2\_transit\_gateway\_vpc\_attachment](#output\_this\_ec2\_transit\_gateway\_vpc\_attachment) | Map of EC2 Transit Gateway VPC Attachment attributes |
+| <a name="output_this_ec2_transit_gateway_vpc_attachment_ids"></a> [this\_ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_this\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
+| <a name="output_this_ram_principal_association_id"></a> [this\_ram\_principal\_association\_id](#output\_this\_ram\_principal\_association\_id) | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
+| <a name="output_this_ram_resource_share_id"></a> [this\_ram\_resource\_share\_id](#output\_this\_ram\_resource\_share\_id) | The Amazon Resource Name (ARN) of the resource share |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
