### PR TITLE
fix: Update map function to work in Terraform 0.15

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
 
   # List of maps with key and route values
   vpc_attachments_with_routes = chunklist(flatten([
-    for k, v in var.vpc_attachments : setproduct([map("key", k)], v["tgw_routes"]) if length(lookup(v, "tgw_routes", {})) > 0
+    for k, v in var.vpc_attachments : setproduct([tomap({"key" = k})], v["tgw_routes"]) if length(lookup(v, "tgw_routes", {})) > 0
   ]), 2)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
 
   # List of maps with key and route values
   vpc_attachments_with_routes = chunklist(flatten([
-    for k, v in var.vpc_attachments : setproduct([tomap({"key" = k})], v["tgw_routes"]) if length(lookup(v, "tgw_routes", {})) > 0
+    for k, v in var.vpc_attachments : setproduct([{key = k}], v["tgw_routes"]) if length(lookup(v, "tgw_routes", {})) > 0
   ]), 2)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
 
   # List of maps with key and route values
   vpc_attachments_with_routes = chunklist(flatten([
-    for k, v in var.vpc_attachments : setproduct([{key = k}], v["tgw_routes"]) if length(lookup(v, "tgw_routes", {})) > 0
+    for k, v in var.vpc_attachments : setproduct([{ key = k }], v["tgw_routes"]) if length(lookup(v, "tgw_routes", {})) > 0
   ]), 2)
 }
 


### PR DESCRIPTION
## Description
Update call to deprecated `map` function to use `tomap` instead

## Motivation and Context
Resolves https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/43

https://www.hashicorp.com/blog/deprecating-terraform-0-11-support-in-terraform-providers

## Breaking Changes
Will break Terraform <0.12

## How Has This Been Tested?
- [x] I have tested and validated these changes using the `examples/complete` project

```
$ terraform version
Terraform v0.15.0
on darwin_amd64
+ provider registry.terraform.io/hashicorp/aws v3.38.0
```
