### PR TITLE
feat: adding appliance_mode_support to vpc attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ module "vpc" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.24 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 
   dns_support                                     = lookup(each.value, "dns_support", true) ? "enable" : "disable"
   ipv6_support                                    = lookup(each.value, "ipv6_support", false) ? "enable" : "disable"
+  appliance_mode_support                          = lookup(each.value, "appliance_mode_support", false) ? "enable" : "disable"
   transit_gateway_default_route_table_association = lookup(each.value, "transit_gateway_default_route_table_association", true)
   transit_gateway_default_route_table_propagation = lookup(each.value, "transit_gateway_default_route_table_propagation", true)
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 2.24"
+    aws = ">= 3.15.0"
   }
 }


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Adds the appliance mode argument to `aws_ec2_transit_gateway_vpc_attachment` in the module and defaults to the resources default setting.  (disabled) 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This adds AWS Appliance mode support as per issue #33

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No Breaking Changes

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested  against a personal AWS dev environment.  
