### PR TITLE
feat: default tgw route table tags (rebased against current HEAD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_ec2_tag.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_ec2_transit_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway) | resource |
 | [aws_ec2_transit_gateway_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
 | [aws_ec2_transit_gateway_route_table.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table) | resource |
@@ -116,6 +117,7 @@ No modules.
 | <a name="input_ram_tags"></a> [ram\_tags](#input\_ram\_tags) | Additional tags for the RAM | `map(string)` | `{}` | no |
 | <a name="input_share_tgw"></a> [share\_tgw](#input\_share\_tgw) | Whether to share your transit gateway with other accounts | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_tgw_default_route_table_tags"></a> [tgw\_default\_route\_table\_tags](#input\_tgw\_default\_route\_table\_tags) | Additional tags for the Default TGW route table | `map(string)` | `{}` | no |
 | <a name="input_tgw_route_table_tags"></a> [tgw\_route\_table\_tags](#input\_tgw\_route\_table\_tags) | Additional tags for the TGW route table | `map(string)` | `{}` | no |
 | <a name="input_tgw_tags"></a> [tgw\_tags](#input\_tgw\_tags) | Additional tags for the TGW | `map(string)` | `{}` | no |
 | <a name="input_tgw_vpc_attachment_tags"></a> [tgw\_vpc\_attachment\_tags](#input\_tgw\_vpc\_attachment\_tags) | Additional tags for VPC attachments | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,14 @@ resource "aws_ec2_transit_gateway" "this" {
   )
 }
 
+resource "aws_ec2_tag" "this" {
+  count = var.create_tgw ? length(var.tgw_default_route_table_tags) : 0
+
+  resource_id = aws_ec2_transit_gateway.this[0].association_default_route_table_id
+  key         = keys(var.tgw_default_route_table_tags)[count.index]
+  value       = values(var.tgw_default_route_table_tags)[count.index]
+}
+
 #########################
 # Route table and routes
 #########################

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,14 @@ locals {
   vpc_attachments_with_routes = chunklist(flatten([
     for k, v in var.vpc_attachments : setproduct([{ key = k }], v["tgw_routes"]) if length(lookup(v, "tgw_routes", {})) > 0
   ]), 2)
+
+  tgw_default_route_table_tags_merged = merge(
+    {
+      "Name" = format("%s", var.name)
+    },
+    var.tags,
+    var.tgw_default_route_table_tags,
+  )
 }
 
 resource "aws_ec2_transit_gateway" "this" {
@@ -34,11 +42,11 @@ resource "aws_ec2_transit_gateway" "this" {
 }
 
 resource "aws_ec2_tag" "this" {
-  count = var.create_tgw ? length(var.tgw_default_route_table_tags) : 0
+  count = var.create_tgw ? length(local.tgw_default_route_table_tags_merged) : 0
 
   resource_id = aws_ec2_transit_gateway.this[0].association_default_route_table_id
-  key         = keys(var.tgw_default_route_table_tags)[count.index]
-  value       = values(var.tgw_default_route_table_tags)[count.index]
+  key         = keys(local.tgw_default_route_table_tags_merged)[count.index]
+  value       = values(local.tgw_default_route_table_tags_merged)[count.index]
 }
 
 #########################

--- a/main.tf
+++ b/main.tf
@@ -42,11 +42,10 @@ resource "aws_ec2_transit_gateway" "this" {
 }
 
 resource "aws_ec2_tag" "this" {
-  count = var.create_tgw ? length(local.tgw_default_route_table_tags_merged) : 0
-
+  for_each    = var.create_tgw ? local.tgw_default_route_table_tags_merged : {}
   resource_id = aws_ec2_transit_gateway.this[0].association_default_route_table_id
-  key         = keys(local.tgw_default_route_table_tags_merged)[count.index]
-  value       = values(local.tgw_default_route_table_tags_merged)[count.index]
+  key         = each.key
+  value       = each.value
 }
 
 #########################

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,12 @@ variable "tgw_route_table_tags" {
   default     = {}
 }
 
+variable "tgw_default_route_table_tags" {
+  description = "Additional tags for the Default TGW route table"
+  type        = map(string)
+  default     = {}
+}
+
 variable "tgw_vpc_attachment_tags" {
   description = "Additional tags for VPC attachments"
   type        = map(string)


### PR DESCRIPTION
## Description

This is this same PR #34  just rebased against current master
<!--- Describe your changes in detail -->

## Motivation and Context

This is a great feature, and IMO much needed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes

This change doesn't break compatibility, however since it uses `count` any change to the tags will generate a bit of resource churn.  It might be worth discussing how desirable the `create_tgw` parameter is in later releases and if we should keep it around. 
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
Tested against my local dev env. 
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
