### PR TITLE
feat: use for each for ram principles (rebased against current HEAD)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.13.0/terraform-docs-v0.13.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.14.1/terraform-docs-v0.14.1-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ module "vpc" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.40.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -32,13 +32,13 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.40.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_tgw"></a> [tgw](#module\_tgw) | ../../ |  |
+| <a name="module_tgw"></a> [tgw](#module\_tgw) | ../../ | n/a |
 | <a name="module_vpc1"></a> [vpc1](#module\_vpc1) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 | <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 

--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -32,14 +32,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.40.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_tgw"></a> [tgw](#module\_tgw) | ../../ |  |
-| <a name="module_tgw_peer"></a> [tgw\_peer](#module\_tgw\_peer) | ../../ |  |
+| <a name="module_tgw"></a> [tgw](#module\_tgw) | ../../ | n/a |
+| <a name="module_tgw_peer"></a> [tgw\_peer](#module\_tgw\_peer) | ../../ | n/a |
 | <a name="module_vpc1"></a> [vpc1](#module\_vpc1) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -160,9 +160,9 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  count = var.create_tgw && var.share_tgw ? length(var.ram_principals) : 0
-
-  principal          = var.ram_principals[count.index]
+  #count = var.create_tgw && var.share_tgw ? length(var.ram_principals) : 0
+  for_each = toset(var.ram_principals)
+  principal          = each.value
   resource_share_arn = aws_ram_resource_share.this[0].arn
 }
 

--- a/main.tf
+++ b/main.tf
@@ -160,7 +160,7 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  for_each = toset(var.ram_principals)
+  for_each           = toset(var.ram_principals)
   principal          = each.value
   resource_share_arn = aws_ram_resource_share.this[0].arn
 }

--- a/main.tf
+++ b/main.tf
@@ -160,7 +160,6 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  #count = var.create_tgw && var.share_tgw ? length(var.ram_principals) : 0
   for_each = toset(var.ram_principals)
   principal          = each.value
   resource_share_arn = aws_ram_resource_share.this[0].arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -88,5 +88,6 @@ output "ram_resource_share_id" {
 # aws_ram_principal_association
 output "ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
-  value       = element(concat(aws_ram_principal_association.this.*.id, [""]), 0)
+  value       = [ for k, v in aws_ram_principal_association.this : v.id ]
+
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -88,6 +88,6 @@ output "ram_resource_share_id" {
 # aws_ram_principal_association
 output "ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
-  value       = [ for k, v in aws_ram_principal_association.this : v.id ]
+  value       = [for k, v in aws_ram_principal_association.this : v.id]
 
 }


### PR DESCRIPTION
## Description
This is a rebase of PR #16 against master

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This is a breaking change *if* the a RAM Principle has been passed to the module, otherwise it's a no-op.  If you've shared the TGW with this module it will attempt to delete and recreate all the `aws_ram_principal_association` resources. This would require the recipient of the share to re-accept the shared RAM principle. 
 basically `aws_ram_principal_association.this["0"]` will be delete and recreated as `aws_ram_principal_association.this["xxxxxxxxxxxx"]`  this can be mitigated by manually using `terraform state mv SOURCE DESTINATION` to migrate.  
 


## How Has This Been Tested?
Tested by sharing a RAM principle between accounts and confirming that the plan/apply with the patch delete and recreate the resource 
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
