### PR TITLE
fix: add tags if the default route table association is enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "aws_ec2_transit_gateway" "this" {
 }
 
 resource "aws_ec2_tag" "this" {
-  for_each    = var.create_tgw ? local.tgw_default_route_table_tags_merged : {}
+  for_each    = var.create_tgw && var.enable_default_route_table_association ? local.tgw_default_route_table_tags_merged : {}
   resource_id = aws_ec2_transit_gateway.this[0].association_default_route_table_id
   key         = each.key
   value       = each.value


### PR DESCRIPTION
## Description
Fixes #51

## Motivation and Context
Attempts to fix this error:

```
Error: error creating EC2 Tag (ops.company.cloud/provisioner) for resource (): error tagging resource (): InvalidParameterValue: Value ( null ) for parameter resourceId is invalid. Null/empty value for resourceId is invalid
	status code: 400, request id: 42192f9f-1546-4714-b9b2-b5b4e948ef64

  on .terraform/modules/tgw/main.tf line 44, in resource "aws_ec2_tag" "this":
  44: resource "aws_ec2_tag" "this" {
```

This would happen when the transit gateway has `enable_default_route_table_association` as false.

## How Has This Been Tested?

