### PR TITLE
Fix for aws_ec2_tag bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "aws_ec2_transit_gateway" "this" {
 }
 
 resource "aws_ec2_tag" "this" {
-  for_each    = var.create_tgw ? local.tgw_default_route_table_tags_merged : {}
+  for_each    = var.create_tgw && var.enable_default_route_table_association ? local.tgw_default_route_table_tags_merged : {}
   resource_id = aws_ec2_transit_gateway.this[0].association_default_route_table_id
   key         = each.key
   value       = each.value


### PR DESCRIPTION
## Description
We still try to create a tag even with default_route_table_association disabled:

```
Error: error creating EC2 Tag (Name) for resource (): error tagging resource (): InvalidParameterValue: Value ( null ) for parameter resourceId is invalid. Null/empty value for resourceId is invalid
	status code: 400, request id: a6612f62-51db-403e-a091-d40d18988a20

  on .terraform/modules/vpc.tgw/main.tf line 53, in resource "aws_ec2_tag" "this":
  53: resource "aws_ec2_tag" "this" {
```
## Motivation and Context
Bug fix

## Breaking Changes
None

## How Has This Been Tested?
None
