### PR TITLE
fix: ignore route table if no attachment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_ec2_tag" "this" {
 # Route table and routes
 #########################
 resource "aws_ec2_transit_gateway_route_table" "this" {
-  count = var.create_tgw ? 1 : 0
+  count = (var.create_tgw && (length(local.vpc_attachments_without_default_route_table_association) > 0 || length(local.vpc_attachments_without_default_route_table_propagation) > 0)) ? 1 : 0
 
   transit_gateway_id = aws_ec2_transit_gateway.this[0].id
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
> Your transit gateway automatically comes with a default route table. By default, this route table is the default association route table and the default propagation route table. Alternatively, if you disable route propagation and route table association, AWS does not create a default route table for the transit gateway.
> https://docs.aws.amazon.com/vpc/latest/tgw/how-transit-gateways-work.html
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If there both route table propagation and association disabled, no default route table created
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No impact
## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
just simply creating a empty transit gateway