### PR TITLE
Add optional variable for transit gateway for multi-account setup

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_route" "this" {
 
   route_table_id         = each.key
   destination_cidr_block = each.value
-  transit_gateway_id     = aws_ec2_transit_gateway.this[0].id
+  transit_gateway_id     = var.create_tgw ? aws_ec2_transit_gateway.this[0].id : var.transit_gateway_id
 }
 
 ###########################################################
@@ -99,7 +99,7 @@ resource "aws_route" "this" {
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   for_each = var.vpc_attachments
 
-  transit_gateway_id = lookup(each.value, "tgw_id", var.create_tgw ? aws_ec2_transit_gateway.this[0].id : null)
+  transit_gateway_id = lookup(each.value, "tgw_id", var.create_tgw ? aws_ec2_transit_gateway.this[0].id : var.transit_gateway_id)
   vpc_id             = each.value["vpc_id"]
   subnet_ids         = each.value["subnet_ids"]
 
@@ -167,7 +167,7 @@ resource "aws_ram_principal_association" "this" {
 }
 
 resource "aws_ram_resource_share_accepter" "this" {
-  count = !var.create_tgw && var.share_tgw ? 1 : 0
+  count = ! var.create_tgw && var.share_tgw ? 1 : 0
 
   share_arn = var.ram_resource_share_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "transit_gateway_route_table_id" {
   default     = null
 }
 
+variable "transit_gateway_id" {
+  description = "Identifier of EC2 Transit Gateway ID to use when using configuring for cross account usage"
+  type        = string
+  default     = null
+}
+
 # Tags
 variable "tags" {
   description = "A map of tags to add to all resources"


### PR DESCRIPTION
## Description
Introduces a new optional variable for transit gateway ID for multi-account set-up

## Motivation and Context
Allows us to create a TGW and share with a VPC in another account
https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/61

## Breaking Changes
Does this break backwards compatibility with the current major version? 
No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ x] I have tested and validated these changes using one or more of the provided `examples/*` projects
This is still in draft state pending clarification of intended behaviour.
Shared TGW has been created and destroyed multiple times in line with multi-account setup
