### PR TITLE
Override tgw attachment name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 
   tags = merge(
     {
-      Name = format("%s-%s", var.name, each.key)
+      Name = lookup(each.value, "name", format("%s-%s", var.name, each.key))
     },
     var.tags,
     var.tgw_vpc_attachment_tags,


### PR DESCRIPTION
## Description
A simple hack to override tag name if key name name is added

## Motivation and Context
I need to change name without remove and delete tgw attachment

## Breaking Changes
No

## How Has This Been Tested?

Add name key in vpc_attachments
