### PR TITLE
fix: Avoid error looking up tgw_route_table when resource is not crea…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,8 @@ locals {
       }
     ]
   ])
+
+  tgw_route_table_id = try(var.transit_gateway_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id)
 }
 
 resource "aws_ec2_transit_gateway" "this" {
@@ -123,7 +125,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "this" {
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = coalesce(lookup(each.value, "transit_gateway_route_table_id", null), var.transit_gateway_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id)
+  transit_gateway_route_table_id = coalesce(lookup(each.value, "transit_gateway_route_table_id", null), local.tgw_route_table_id)
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
@@ -131,7 +133,8 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = coalesce(lookup(each.value, "transit_gateway_route_table_id", null), var.transit_gateway_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id)
+  transit_gateway_route_table_id = coalesce(lookup(each.value, "transit_gateway_route_table_id", null), local.tgw_route_table_id)
+
 }
 
 ##########################

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,6 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
   transit_gateway_route_table_id = coalesce(lookup(each.value, "transit_gateway_route_table_id", null), local.tgw_route_table_id)
-
 }
 
 ##########################


### PR DESCRIPTION
## Description
When sharing a tgw across aws accounts (tgw_share=true and tgw_create=false), the module runs into an error when looking up the transit gateway route table. By introducing a local variable with 'try' we can circumvent the issue.

## Motivation and Context
Module fails when trying to share across accounts. Previous issues reported:
https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/61
https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/46
https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/47
https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/56

## Breaking Changes
none
