### PR TITLE
feat: Update Terraform minimum supported version to `v0.13.1`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.64.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ module "vpc" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -2,12 +2,6 @@
 
 Configuration in this directory creates AWS Transit Gateway, attach VPC to it and share it with other AWS principals using [Resource Access Manager (RAM)](https://aws.amazon.com/ram/).
 
-## Notes
-
-There is a famous limitation in Terraform which prevents us from using computed values in `count`. For this reason this example is using data-sources to discover already created default VPC and subnets.
-
-In real-world scenario you will have to split creation of VPC (using [terraform-aws-vpc modules](https://github.com/terraform-aws-modules/terraform-aws-vpc)) and creation of TGW resources using this module. 
-
 ## Usage
 
 To run this example you need to execute:
@@ -30,9 +24,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+No providers.
 
 ## Modules
 
@@ -44,12 +36,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_subnets.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
-| [aws_subnets.vpc2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
-| [aws_vpc.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
-| [aws_vpc.vpc2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+No resources.
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -46,8 +46,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_subnet_ids.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
-| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [aws_subnet_ids.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnet_ids.vpc2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [aws_vpc.vpc2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,14 +25,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.24 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -46,8 +46,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_subnet_ids.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
-| [aws_subnet_ids.vpc2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.vpc2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [aws_vpc.vpc2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -24,18 +24,18 @@ module "tgw" {
   description     = "My TGW shared with several other AWS accounts"
   amazon_side_asn = 64532
 
-  enable_auto_accept_shared_attachments = true # When "true" there is no need for RAM resources if using multiple AWS accounts
+  # When "true" there is no need for RAM resources if using multiple AWS accounts
+  enable_auto_accept_shared_attachments = true
 
   vpc_attachments = {
     vpc1 = {
-      vpc_id       = data.aws_vpc.vpc1.id      # module.vpc1.vpc_id
-      subnet_ids   = data.aws_subnets.vpc1.ids # module.vpc1.private_subnets
+      vpc_id       = module.vpc1.vpc_id
+      subnet_ids   = module.vpc1.private_subnets
       dns_support  = true
       ipv6_support = true
 
       transit_gateway_default_route_table_association = false
       transit_gateway_default_route_table_propagation = false
-      # transit_gateway_route_table_id                  = "tgw-rtb-073a181ee589b360f"
 
       tgw_routes = [
         {
@@ -48,8 +48,8 @@ module "tgw" {
       ]
     },
     vpc2 = {
-      vpc_id     = data.aws_vpc.vpc2.id      # module.vpc2.vpc_id
-      subnet_ids = data.aws_subnets.vpc2.ids # module.vpc2.private_subnets
+      vpc_id     = module.vpc2.vpc_id
+      subnet_ids = module.vpc2.private_subnets
 
       tgw_routes = [
         {
@@ -90,18 +90,6 @@ module "vpc1" {
   tags = local.tags
 }
 
-# See Notes in README.md for explanation regarding using data-sources and computed values
-data "aws_vpc" "vpc1" {
-  id = module.vpc1.vpc_id
-}
-
-data "aws_subnets" "vpc1" {
-  filter {
-    name   = "vpc-id"
-    values = [module.vpc1.vpc_id]
-  }
-}
-
 module "vpc2" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
@@ -115,16 +103,4 @@ module "vpc2" {
   enable_ipv6 = false
 
   tags = local.tags
-}
-
-# See Notes in README.md for explanation regarding using data-sources and computed values
-data "aws_vpc" "vpc2" {
-  id = module.vpc2.vpc_id
-}
-
-data "aws_subnets" "vpc2" {
-  filter {
-    name   = "vpc-id"
-    values = [module.vpc2.vpc_id]
-  }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,20 +1,26 @@
 provider "aws" {
+  region = local.region
+}
+
+locals {
+  name   = "ex-tgw-${replace(basename(path.cwd), "_", "-")}"
   region = "eu-west-1"
+
+  tags = {
+    Example    = local.name
+    GithubRepo = "terraform-aws-eks"
+    GithubOrg  = "terraform-aws-transit-gateway"
+  }
 }
 
-# See Notes in README.md for explanation regarding using data-sources and computed values
-data "aws_vpc" "default" {
-  default = true
-}
-
-data "aws_subnet_ids" "this" {
-  vpc_id = data.aws_vpc.default.id
-}
+################################################################################
+# Transit Gateway Module
+################################################################################
 
 module "tgw" {
   source = "../../"
 
-  name            = "my-tgw"
+  name            = local.name
   description     = "My TGW shared with several other AWS accounts"
   amazon_side_asn = 64532
 
@@ -22,13 +28,14 @@ module "tgw" {
 
   vpc_attachments = {
     vpc1 = {
-      vpc_id                                          = data.aws_vpc.default.id      # module.vpc1.vpc_id
-      subnet_ids                                      = data.aws_subnet_ids.this.ids # module.vpc1.private_subnets
-      dns_support                                     = true
-      ipv6_support                                    = true
+      vpc_id       = data.aws_vpc.vpc1.id      # module.vpc1.vpc_id
+      subnet_ids   = data.aws_subnets.vpc1.ids # module.vpc1.private_subnets
+      dns_support  = true
+      ipv6_support = true
+
       transit_gateway_default_route_table_association = false
       transit_gateway_default_route_table_propagation = false
-      #      transit_gateway_route_table_id = "tgw-rtb-073a181ee589b360f"
+      # transit_gateway_route_table_id                  = "tgw-rtb-073a181ee589b360f"
 
       tgw_routes = [
         {
@@ -41,8 +48,8 @@ module "tgw" {
       ]
     },
     vpc2 = {
-      vpc_id     = data.aws_vpc.default.id      # module.vpc2.vpc_id
-      subnet_ids = data.aws_subnet_ids.this.ids # module.vpc2.private_subnets
+      vpc_id     = data.aws_vpc.vpc2.id      # module.vpc2.vpc_id
+      subnet_ids = data.aws_subnets.vpc2.ids # module.vpc2.private_subnets
 
       tgw_routes = [
         {
@@ -59,37 +66,65 @@ module "tgw" {
   ram_allow_external_principals = true
   ram_principals                = [307990089504]
 
-  tags = {
-    Purpose = "tgw-complete-example"
-  }
+  tags = local.tags
 }
+
+################################################################################
+# Supporting resources
+################################################################################
 
 module "vpc1" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
 
-  name = "vpc1"
-
+  name = "${local.name}-vpc1"
   cidr = "10.10.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
   private_subnets = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
 
   enable_ipv6                                    = true
   private_subnet_assign_ipv6_address_on_creation = true
   private_subnet_ipv6_prefixes                   = [0, 1, 2]
+
+  tags = local.tags
+}
+
+# See Notes in README.md for explanation regarding using data-sources and computed values
+data "aws_vpc" "vpc1" {
+  id = module.vpc1.vpc_id
+}
+
+data "aws_subnets" "vpc1" {
+  filter {
+    name   = "vpc-id"
+    values = [module.vpc1.vpc_id]
+  }
 }
 
 module "vpc2" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
 
-  name = "vpc2"
-
+  name = "${local.name}-vpc2"
   cidr = "10.20.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
   private_subnets = ["10.20.1.0/24", "10.20.2.0/24", "10.20.3.0/24"]
 
   enable_ipv6 = false
+
+  tags = local.tags
+}
+
+# See Notes in README.md for explanation regarding using data-sources and computed values
+data "aws_vpc" "vpc2" {
+  id = module.vpc2.vpc_id
+}
+
+data "aws_subnets" "vpc2" {
+  filter {
+    name   = "vpc-id"
+    values = [module.vpc2.vpc_id]
+  }
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,12 +1,10 @@
-# aws_ec2_transit_gateway
+################################################################################
+# Transit Gateway
+################################################################################
+
 output "ec2_transit_gateway_arn" {
   description = "EC2 Transit Gateway Amazon Resource Name (ARN)"
   value       = module.tgw.ec2_transit_gateway_arn
-}
-
-output "ec2_transit_gateway_association_default_route_table_id" {
-  description = "Identifier of the default association route table"
-  value       = module.tgw.ec2_transit_gateway_association_default_route_table_id
 }
 
 output "ec2_transit_gateway_id" {
@@ -19,9 +17,37 @@ output "ec2_transit_gateway_owner_id" {
   value       = module.tgw.ec2_transit_gateway_owner_id
 }
 
+output "ec2_transit_gateway_association_default_route_table_id" {
+  description = "Identifier of the default association route table"
+  value       = module.tgw.ec2_transit_gateway_association_default_route_table_id
+}
+
 output "ec2_transit_gateway_propagation_default_route_table_id" {
   description = "Identifier of the default propagation route table"
   value       = module.tgw.ec2_transit_gateway_propagation_default_route_table_id
+}
+
+################################################################################
+# VPC Attachment
+################################################################################
+
+output "ec2_transit_gateway_vpc_attachment_ids" {
+  description = "List of EC2 Transit Gateway VPC Attachment identifiers"
+  value       = module.tgw.ec2_transit_gateway_vpc_attachment_ids
+}
+
+output "ec2_transit_gateway_vpc_attachment" {
+  description = "Map of EC2 Transit Gateway VPC Attachment attributes"
+  value       = module.tgw.ec2_transit_gateway_vpc_attachment
+}
+
+################################################################################
+# Route Table / Routes
+################################################################################
+
+output "ec2_transit_gateway_route_table_id" {
+  description = "EC2 Transit Gateway Route Table identifier"
+  value       = module.tgw.ec2_transit_gateway_route_table_id
 }
 
 output "ec2_transit_gateway_route_table_default_association_route_table" {
@@ -34,30 +60,11 @@ output "ec2_transit_gateway_route_table_default_propagation_route_table" {
   value       = module.tgw.ec2_transit_gateway_route_table_default_propagation_route_table
 }
 
-# aws_ec2_transit_gateway_route_table
-output "ec2_transit_gateway_route_table_id" {
-  description = "EC2 Transit Gateway Route Table identifier"
-  value       = module.tgw.ec2_transit_gateway_route_table_id
-}
-
-# aws_ec2_transit_gateway_route
 output "ec2_transit_gateway_route_ids" {
   description = "List of EC2 Transit Gateway Route Table identifier combined with destination"
   value       = module.tgw.ec2_transit_gateway_route_ids
 }
 
-# aws_ec2_transit_gateway_vpc_attachment
-output "ec2_transit_gateway_vpc_attachment_ids" {
-  description = "List of EC2 Transit Gateway VPC Attachment identifiers"
-  value       = module.tgw.ec2_transit_gateway_vpc_attachment_ids
-}
-
-output "ec2_transit_gateway_vpc_attachment" {
-  description = "Map of EC2 Transit Gateway VPC Attachment attributes"
-  value       = module.tgw.ec2_transit_gateway_vpc_attachment
-}
-
-# aws_ec2_transit_gateway_route_table_association
 output "ec2_transit_gateway_route_table_association_ids" {
   description = "List of EC2 Transit Gateway Route Table Association identifiers"
   value       = module.tgw.ec2_transit_gateway_route_table_association_ids
@@ -68,7 +75,6 @@ output "ec2_transit_gateway_route_table_association" {
   value       = module.tgw.ec2_transit_gateway_route_table_association
 }
 
-# aws_ec2_transit_gateway_route_table_propagation
 output "ec2_transit_gateway_route_table_propagation_ids" {
   description = "List of EC2 Transit Gateway Route Table Propagation identifiers"
   value       = module.tgw.ec2_transit_gateway_route_table_propagation_ids
@@ -79,13 +85,15 @@ output "ec2_transit_gateway_route_table_propagation" {
   value       = module.tgw.ec2_transit_gateway_route_table_propagation
 }
 
-# aws_ram_resource_share
+################################################################################
+# Resource Access Manager
+################################################################################
+
 output "ram_resource_share_id" {
   description = "The Amazon Resource Name (ARN) of the resource share"
   value       = module.tgw.ram_resource_share_id
 }
 
-# aws_ram_principal_association
 output "ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
   value       = module.tgw.ram_principal_association_id

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 2.24"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.15"
+    }
   }
 }

--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -46,8 +46,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_subnet_ids.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
-| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [aws_subnet_ids.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 

--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -25,14 +25,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.24 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
 
 ## Modules
 

--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -46,7 +46,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_subnet_ids.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -2,12 +2,6 @@
 
 Configuration in this directory creates AWS Transit Gateway, attach VPC to it and share it with other AWS principals using [Resource Access Manager (RAM)](https://aws.amazon.com/ram/).
 
-## Notes
-
-There is a famous limitation in Terraform which prevents us from using computed values in `count`. For this reason this example is using data-sources to discover already created default VPC and subnets.
-
-In real-world scenario you will have to split creation of VPC (using [terraform-aws-vpc modules](https://github.com/terraform-aws-modules/terraform-aws-vpc)) and creation of TGW resources using this module. 
-
 ## Usage
 
 To run this example you need to execute:
@@ -30,9 +24,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+No providers.
 
 ## Modules
 
@@ -41,13 +33,11 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_tgw"></a> [tgw](#module\_tgw) | ../../ | n/a |
 | <a name="module_tgw_peer"></a> [tgw\_peer](#module\_tgw\_peer) | ../../ | n/a |
 | <a name="module_vpc1"></a> [vpc1](#module\_vpc1) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_subnets.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
-| [aws_vpc.vpc1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+No resources.
 
 ## Inputs
 

--- a/examples/multi-account/main.tf
+++ b/examples/multi-account/main.tf
@@ -1,26 +1,32 @@
 provider "aws" {
-  region = "eu-west-1"
+  region = local.region
 }
 
-# This provider is required for attachment only installation in another AWS Account.
+# This provider is required for attachment only installation in another AWS Account
 provider "aws" {
-  region = "eu-west-1"
+  region = local.region
   alias  = "peer"
 }
 
-# See Notes in README.md for explanation regarding using data-sources and computed values
-data "aws_vpc" "default" {
-  default = true
+locals {
+  name   = "ex-tgw-${replace(basename(path.cwd), "_", "-")}"
+  region = "eu-west-1"
+
+  tags = {
+    Example    = local.name
+    GithubRepo = "terraform-aws-eks"
+    GithubOrg  = "terraform-aws-transit-gateway"
+  }
 }
 
-data "aws_subnet_ids" "this" {
-  vpc_id = data.aws_vpc.default.id
-}
+################################################################################
+# Transit Gateway Module
+################################################################################
 
 module "tgw" {
   source = "../../"
 
-  name            = "my-tgw"
+  name            = local.name
   description     = "My TGW shared with several other AWS accounts"
   amazon_side_asn = 64532
 
@@ -28,13 +34,14 @@ module "tgw" {
 
   vpc_attachments = {
     vpc1 = {
-      vpc_id                                          = data.aws_vpc.default.id      # module.vpc1.vpc_id
-      subnet_ids                                      = data.aws_subnet_ids.this.ids # module.vpc1.private_subnets
-      dns_support                                     = true
-      ipv6_support                                    = true
+      vpc_id       = data.aws_vpc.vpc1.id      # module.vpc1.vpc_id
+      subnet_ids   = data.aws_subnets.vpc1.ids # module.vpc1.private_subnets
+      dns_support  = true
+      ipv6_support = true
+
       transit_gateway_default_route_table_association = false
       transit_gateway_default_route_table_propagation = false
-      #      transit_gateway_route_table_id = "tgw-rtb-073a181ee589b360f"
+      # transit_gateway_route_table_id                  = "tgw-rtb-073a181ee589b360f"
 
       tgw_routes = [
         {
@@ -47,8 +54,8 @@ module "tgw" {
       ]
     },
     vpc2 = {
-      vpc_id     = data.aws_vpc.default.id      # module.vpc2.vpc_id
-      subnet_ids = data.aws_subnet_ids.this.ids # module.vpc2.private_subnets
+      vpc_id     = data.aws_vpc.vpc1.id      # module.vpc2.vpc_id
+      subnet_ids = data.aws_subnets.vpc1.ids # module.vpc2.private_subnets
 
       tgw_routes = [
         {
@@ -65,9 +72,7 @@ module "tgw" {
   ram_allow_external_principals = true
   ram_principals                = [307990089504]
 
-  tags = {
-    Purpose = "tgw-complete-example"
-  }
+  tags = local.tags
 }
 
 module "tgw_peer" {
@@ -78,7 +83,7 @@ module "tgw_peer" {
     aws = aws.peer
   }
 
-  name            = "my-tgw-peer"
+  name            = "${local.name}-peer"
   description     = "My TGW shared with several other AWS accounts"
   amazon_side_asn = 64532
 
@@ -89,14 +94,15 @@ module "tgw_peer" {
 
   vpc_attachments = {
     vpc1 = {
-      tgw_id                                          = module.tgw.ec2_transit_gateway_id
-      vpc_id                                          = data.aws_vpc.default.id      # module.vpc1.vpc_id
-      subnet_ids                                      = data.aws_subnet_ids.this.ids # module.vpc1.private_subnets
-      dns_support                                     = true
-      ipv6_support                                    = true
+      tgw_id       = module.tgw.ec2_transit_gateway_id
+      vpc_id       = data.aws_vpc.vpc1.id      # module.vpc1.vpc_id
+      subnet_ids   = data.aws_subnets.vpc1.ids # module.vpc1.private_subnets
+      dns_support  = true
+      ipv6_support = true
+
       transit_gateway_default_route_table_association = false
       transit_gateway_default_route_table_propagation = false
-      #      transit_gateway_route_table_id = "tgw-rtb-073a181ee589b360f"
+      # transit_gateway_route_table_id                  = "tgw-rtb-073a181ee589b360f"
 
       tgw_routes = [
         {
@@ -113,23 +119,38 @@ module "tgw_peer" {
   ram_allow_external_principals = true
   ram_principals                = [307990089504]
 
-  tags = {
-    Purpose = "tgw-complete-example"
-  }
+  tags = local.tags
 }
+
+################################################################################
+# Supporting resources
+################################################################################
 
 module "vpc1" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
 
-  name = "vpc1"
-
+  name = "${local.name}-vpc1"
   cidr = "10.10.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
   private_subnets = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
 
   enable_ipv6                                    = true
   private_subnet_assign_ipv6_address_on_creation = true
   private_subnet_ipv6_prefixes                   = [0, 1, 2]
+
+  tags = local.tags
+}
+
+# See Notes in README.md for explanation regarding using data-sources and computed values
+data "aws_vpc" "vpc1" {
+  id = module.vpc1.vpc_id
+}
+
+data "aws_subnets" "vpc1" {
+  filter {
+    name   = "vpc-id"
+    values = [module.vpc1.vpc_id]
+  }
 }

--- a/examples/multi-account/main.tf
+++ b/examples/multi-account/main.tf
@@ -87,8 +87,8 @@ module "tgw_peer" {
   description     = "My TGW shared with several other AWS accounts"
   amazon_side_asn = 64532
 
-  share_tgw                             = true
   create_tgw                            = false
+  share_tgw                             = true
   ram_resource_share_arn                = module.tgw.ram_resource_share_id
   enable_auto_accept_shared_attachments = true # When "true" there is no need for RAM resources if using multiple AWS accounts
 

--- a/examples/multi-account/outputs.tf
+++ b/examples/multi-account/outputs.tf
@@ -1,12 +1,10 @@
-# aws_ec2_transit_gateway
+################################################################################
+# Transit Gateway
+################################################################################
+
 output "ec2_transit_gateway_arn" {
   description = "EC2 Transit Gateway Amazon Resource Name (ARN)"
   value       = module.tgw.ec2_transit_gateway_arn
-}
-
-output "ec2_transit_gateway_association_default_route_table_id" {
-  description = "Identifier of the default association route table"
-  value       = module.tgw.ec2_transit_gateway_association_default_route_table_id
 }
 
 output "ec2_transit_gateway_id" {
@@ -19,9 +17,37 @@ output "ec2_transit_gateway_owner_id" {
   value       = module.tgw.ec2_transit_gateway_owner_id
 }
 
+output "ec2_transit_gateway_association_default_route_table_id" {
+  description = "Identifier of the default association route table"
+  value       = module.tgw.ec2_transit_gateway_association_default_route_table_id
+}
+
 output "ec2_transit_gateway_propagation_default_route_table_id" {
   description = "Identifier of the default propagation route table"
   value       = module.tgw.ec2_transit_gateway_propagation_default_route_table_id
+}
+
+################################################################################
+# VPC Attachment
+################################################################################
+
+output "ec2_transit_gateway_vpc_attachment_ids" {
+  description = "List of EC2 Transit Gateway VPC Attachment identifiers"
+  value       = module.tgw.ec2_transit_gateway_vpc_attachment_ids
+}
+
+output "ec2_transit_gateway_vpc_attachment" {
+  description = "Map of EC2 Transit Gateway VPC Attachment attributes"
+  value       = module.tgw.ec2_transit_gateway_vpc_attachment
+}
+
+################################################################################
+# Route Table / Routes
+################################################################################
+
+output "ec2_transit_gateway_route_table_id" {
+  description = "EC2 Transit Gateway Route Table identifier"
+  value       = module.tgw.ec2_transit_gateway_route_table_id
 }
 
 output "ec2_transit_gateway_route_table_default_association_route_table" {
@@ -34,30 +60,11 @@ output "ec2_transit_gateway_route_table_default_propagation_route_table" {
   value       = module.tgw.ec2_transit_gateway_route_table_default_propagation_route_table
 }
 
-# aws_ec2_transit_gateway_route_table
-output "ec2_transit_gateway_route_table_id" {
-  description = "EC2 Transit Gateway Route Table identifier"
-  value       = module.tgw.ec2_transit_gateway_route_table_id
-}
-
-# aws_ec2_transit_gateway_route
 output "ec2_transit_gateway_route_ids" {
   description = "List of EC2 Transit Gateway Route Table identifier combined with destination"
   value       = module.tgw.ec2_transit_gateway_route_ids
 }
 
-# aws_ec2_transit_gateway_vpc_attachment
-output "ec2_transit_gateway_vpc_attachment_ids" {
-  description = "List of EC2 Transit Gateway VPC Attachment identifiers"
-  value       = module.tgw.ec2_transit_gateway_vpc_attachment_ids
-}
-
-output "ec2_transit_gateway_vpc_attachment" {
-  description = "Map of EC2 Transit Gateway VPC Attachment attributes"
-  value       = module.tgw.ec2_transit_gateway_vpc_attachment
-}
-
-# aws_ec2_transit_gateway_route_table_association
 output "ec2_transit_gateway_route_table_association_ids" {
   description = "List of EC2 Transit Gateway Route Table Association identifiers"
   value       = module.tgw.ec2_transit_gateway_route_table_association_ids
@@ -68,7 +75,6 @@ output "ec2_transit_gateway_route_table_association" {
   value       = module.tgw.ec2_transit_gateway_route_table_association
 }
 
-# aws_ec2_transit_gateway_route_table_propagation
 output "ec2_transit_gateway_route_table_propagation_ids" {
   description = "List of EC2 Transit Gateway Route Table Propagation identifiers"
   value       = module.tgw.ec2_transit_gateway_route_table_propagation_ids
@@ -79,13 +85,15 @@ output "ec2_transit_gateway_route_table_propagation" {
   value       = module.tgw.ec2_transit_gateway_route_table_propagation
 }
 
-# aws_ram_resource_share
+################################################################################
+# Resource Access Manager
+################################################################################
+
 output "ram_resource_share_id" {
   description = "The Amazon Resource Name (ARN) of the resource share"
   value       = module.tgw.ram_resource_share_id
 }
 
-# aws_ram_principal_association
 output "ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
   value       = module.tgw.ram_principal_association_id

--- a/examples/multi-account/versions.tf
+++ b/examples/multi-account/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 2.24"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.15"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # List of maps with key and route values
   vpc_attachments_with_routes = chunklist(flatten([
-    for k, v in var.vpc_attachments : setproduct([{ key = k }], v.tgw_routes) if can(v.tgw_routes)
+    for k, v in var.vpc_attachments : setproduct([{ key = k }], v.tgw_routes) if var.create_tgw && can(v.tgw_routes)
   ]), 2)
 
   tgw_default_route_table_tags_merged = merge(
@@ -110,7 +110,7 @@ resource "aws_route" "this" {
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {
   for_each = {
-    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_association, true) != true
+    for k, v in var.vpc_attachments : k => v if var.create_tgw && try(v.transit_gateway_default_route_table_association, true) != true
   }
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
@@ -120,7 +120,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "this" {
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
   for_each = {
-    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_propagation, true) != true
+    for k, v in var.vpc_attachments : k => v if var.create_tgw && try(v.transit_gateway_default_route_table_propagation, true) != true
   }
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,7 @@
 locals {
-  vpc_attachments_without_default_route_table_association = {
-    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_association", true) != true
-  }
-
-  vpc_attachments_without_default_route_table_propagation = {
-    for k, v in var.vpc_attachments : k => v if lookup(v, "transit_gateway_default_route_table_propagation", true) != true
-  }
-
   # List of maps with key and route values
   vpc_attachments_with_routes = chunklist(flatten([
-    for k, v in var.vpc_attachments : setproduct([{ key = k }], v["tgw_routes"]) if length(lookup(v, "tgw_routes", {})) > 0
+    for k, v in var.vpc_attachments : setproduct([{ key = k }], v.tgw_routes) if can(v.tgw_routes)
   ]), 2)
 
   tgw_default_route_table_tags_merged = merge(
@@ -20,13 +12,17 @@ locals {
 
   vpc_route_table_destination_cidr = flatten([
     for k, v in var.vpc_attachments : [
-      for rtb_id in lookup(v, "vpc_route_table_ids", []) : {
+      for rtb_id in try(v.vpc_route_table_ids, []) : {
         rtb_id = rtb_id
-        cidr   = v["tgw_destination_cidr"]
+        cidr   = v.tgw_destination_cidr
       }
     ]
   ])
 }
+
+################################################################################
+# Transit Gateway
+################################################################################
 
 resource "aws_ec2_transit_gateway" "this" {
   count = var.create_tgw ? 1 : 0
@@ -47,15 +43,40 @@ resource "aws_ec2_transit_gateway" "this" {
 }
 
 resource "aws_ec2_tag" "this" {
-  for_each    = var.create_tgw && var.enable_default_route_table_association ? local.tgw_default_route_table_tags_merged : {}
+  for_each = { for k, v in local.tgw_default_route_table_tags_merged : k => v if var.create_tgw && var.enable_default_route_table_association }
+
   resource_id = aws_ec2_transit_gateway.this[0].association_default_route_table_id
   key         = each.key
   value       = each.value
 }
 
-#########################
-# Route table and routes
-#########################
+################################################################################
+# VPC Attachment
+################################################################################
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
+  for_each = var.vpc_attachments
+
+  transit_gateway_id = var.create_tgw ? aws_ec2_transit_gateway.this[0].id : each.value.tgw_id
+  vpc_id             = each.value.vpc_id
+  subnet_ids         = each.value.subnet_ids
+
+  dns_support                                     = try(each.value.dns_support, true) ? "enable" : "disable"
+  ipv6_support                                    = try(each.value.ipv6_support, false) ? "enable" : "disable"
+  appliance_mode_support                          = try(each.value.appliance_mode_support, false) ? "enable" : "disable"
+  transit_gateway_default_route_table_association = try(each.value.transit_gateway_default_route_table_association, true)
+  transit_gateway_default_route_table_propagation = try(each.value.transit_gateway_default_route_table_propagation, true)
+
+  tags = merge(
+    var.tags,
+    { Name = var.name },
+    var.tgw_vpc_attachment_tags,
+  )
+}
+
+################################################################################
+# Route Table / Routes
+################################################################################
 
 resource "aws_ec2_transit_gateway_route_table" "this" {
   count = var.create_tgw ? 1 : 0
@@ -69,15 +90,14 @@ resource "aws_ec2_transit_gateway_route_table" "this" {
   )
 }
 
-# VPC attachment routes
 resource "aws_ec2_transit_gateway_route" "this" {
   count = length(local.vpc_attachments_with_routes)
 
-  destination_cidr_block = local.vpc_attachments_with_routes[count.index][1]["destination_cidr_block"]
-  blackhole              = lookup(local.vpc_attachments_with_routes[count.index][1], "blackhole", null)
+  destination_cidr_block = local.vpc_attachments_with_routes[count.index][1].destination_cidr_block
+  blackhole              = try(local.vpc_attachments_with_routes[count.index][1].blackhole, null)
 
   transit_gateway_route_table_id = var.create_tgw ? aws_ec2_transit_gateway_route_table.this[0].id : var.transit_gateway_route_table_id
-  transit_gateway_attachment_id  = tobool(lookup(local.vpc_attachments_with_routes[count.index][1], "blackhole", false)) == false ? aws_ec2_transit_gateway_vpc_attachment.this[local.vpc_attachments_with_routes[count.index][0]["key"]].id : null
+  transit_gateway_attachment_id  = tobool(try(local.vpc_attachments_with_routes[count.index][1].blackhole, false)) == false ? aws_ec2_transit_gateway_vpc_attachment.this[local.vpc_attachments_with_routes[count.index][0].key].id : null
 }
 
 resource "aws_route" "this" {
@@ -88,49 +108,29 @@ resource "aws_route" "this" {
   transit_gateway_id     = aws_ec2_transit_gateway.this[0].id
 }
 
-###########################################################
-# VPC Attachments, route table association and propagation
-###########################################################
-
-resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
-  for_each = var.vpc_attachments
-
-  transit_gateway_id = lookup(each.value, "tgw_id", var.create_tgw ? aws_ec2_transit_gateway.this[0].id : null)
-  vpc_id             = each.value["vpc_id"]
-  subnet_ids         = each.value["subnet_ids"]
-
-  dns_support                                     = lookup(each.value, "dns_support", true) ? "enable" : "disable"
-  ipv6_support                                    = lookup(each.value, "ipv6_support", false) ? "enable" : "disable"
-  appliance_mode_support                          = lookup(each.value, "appliance_mode_support", false) ? "enable" : "disable"
-  transit_gateway_default_route_table_association = lookup(each.value, "transit_gateway_default_route_table_association", true)
-  transit_gateway_default_route_table_propagation = lookup(each.value, "transit_gateway_default_route_table_propagation", true)
-
-  tags = merge(
-    var.tags,
-    { Name = var.name },
-    var.tgw_vpc_attachment_tags,
-  )
-}
-
 resource "aws_ec2_transit_gateway_route_table_association" "this" {
-  for_each = local.vpc_attachments_without_default_route_table_association
+  for_each = {
+    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_association, true) != true
+  }
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = coalesce(lookup(each.value, "transit_gateway_route_table_id", null), var.transit_gateway_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id)
+  transit_gateway_route_table_id = var.create_tgw ? aws_ec2_transit_gateway_route_table.this[0].id : try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id)
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
-  for_each = local.vpc_attachments_without_default_route_table_propagation
+  for_each = {
+    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_propagation, true) != true
+  }
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = coalesce(lookup(each.value, "transit_gateway_route_table_id", null), var.transit_gateway_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id)
+  transit_gateway_route_table_id = var.create_tgw ? aws_ec2_transit_gateway_route_table.this[0].id : try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id)
 }
 
-##########################
+################################################################################
 # Resource Access Manager
-##########################
+################################################################################
 
 resource "aws_ram_resource_share" "this" {
   count = var.create_tgw && var.share_tgw ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -13,10 +13,8 @@ locals {
   ]), 2)
 
   tgw_default_route_table_tags_merged = merge(
-    {
-      "Name" = format("%s", var.name)
-    },
     var.tags,
+    { Name = var.name },
     var.tgw_default_route_table_tags,
   )
 
@@ -42,10 +40,8 @@ resource "aws_ec2_transit_gateway" "this" {
   dns_support                     = var.enable_dns_support ? "enable" : "disable"
 
   tags = merge(
-    {
-      "Name" = format("%s", var.name)
-    },
     var.tags,
+    { Name = var.name },
     var.tgw_tags,
   )
 }
@@ -60,16 +56,15 @@ resource "aws_ec2_tag" "this" {
 #########################
 # Route table and routes
 #########################
+
 resource "aws_ec2_transit_gateway_route_table" "this" {
   count = var.create_tgw ? 1 : 0
 
   transit_gateway_id = aws_ec2_transit_gateway.this[0].id
 
   tags = merge(
-    {
-      "Name" = format("%s", var.name)
-    },
     var.tags,
+    { Name = var.name },
     var.tgw_route_table_tags,
   )
 }
@@ -96,6 +91,7 @@ resource "aws_route" "this" {
 ###########################################################
 # VPC Attachments, route table association and propagation
 ###########################################################
+
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   for_each = var.vpc_attachments
 
@@ -110,10 +106,8 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   transit_gateway_default_route_table_propagation = lookup(each.value, "transit_gateway_default_route_table_propagation", true)
 
   tags = merge(
-    {
-      Name = format("%s-%s", var.name, each.key)
-    },
     var.tags,
+    { Name = var.name },
     var.tgw_vpc_attachment_tags,
   )
 }
@@ -137,6 +131,7 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
 ##########################
 # Resource Access Manager
 ##########################
+
 resource "aws_ram_resource_share" "this" {
   count = var.create_tgw && var.share_tgw ? 1 : 0
 
@@ -144,10 +139,8 @@ resource "aws_ram_resource_share" "this" {
   allow_external_principals = var.ram_allow_external_principals
 
   tags = merge(
-    {
-      "Name" = format("%s", coalesce(var.ram_name, var.name))
-    },
     var.tags,
+    { Name = coalesce(var.ram_name, var.name) },
     var.ram_tags,
   )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,49 +1,49 @@
 # aws_ec2_transit_gateway
 output "ec2_transit_gateway_arn" {
   description = "EC2 Transit Gateway Amazon Resource Name (ARN)"
-  value       = element(concat(aws_ec2_transit_gateway.this.*.arn, [""]), 0)
+  value       = try(aws_ec2_transit_gateway.this[0].arn, "")
 }
 
 output "ec2_transit_gateway_association_default_route_table_id" {
   description = "Identifier of the default association route table"
-  value       = element(concat(aws_ec2_transit_gateway.this.*.association_default_route_table_id, [""]), 0)
+  value       = try(aws_ec2_transit_gateway.this[0].association_default_route_table_id, "")
 }
 
 output "ec2_transit_gateway_id" {
   description = "EC2 Transit Gateway identifier"
-  value       = element(concat(aws_ec2_transit_gateway.this.*.id, [""]), 0)
+  value       = try(aws_ec2_transit_gateway.this[0].id, "")
 }
 
 output "ec2_transit_gateway_owner_id" {
   description = "Identifier of the AWS account that owns the EC2 Transit Gateway"
-  value       = element(concat(aws_ec2_transit_gateway.this.*.owner_id, [""]), 0)
+  value       = try(aws_ec2_transit_gateway.this[0].owner_id, "")
 }
 
 output "ec2_transit_gateway_propagation_default_route_table_id" {
   description = "Identifier of the default propagation route table"
-  value       = element(concat(aws_ec2_transit_gateway.this.*.propagation_default_route_table_id, [""]), 0)
+  value       = try(aws_ec2_transit_gateway.this[0].propagation_default_route_table_id, "")
 }
 
 # aws_ec2_transit_gateway_route_table
 output "ec2_transit_gateway_route_table_default_association_route_table" {
   description = "Boolean whether this is the default association route table for the EC2 Transit Gateway"
-  value       = element(concat(aws_ec2_transit_gateway_route_table.this.*.default_association_route_table, [""]), 0)
+  value       = try(aws_ec2_transit_gateway_route_table.this[0].default_association_route_table, "")
 }
 
 output "ec2_transit_gateway_route_table_default_propagation_route_table" {
   description = "Boolean whether this is the default propagation route table for the EC2 Transit Gateway"
-  value       = element(concat(aws_ec2_transit_gateway_route_table.this.*.default_propagation_route_table, [""]), 0)
+  value       = try(aws_ec2_transit_gateway_route_table.this[0].default_propagation_route_table, "")
 }
 
 output "ec2_transit_gateway_route_table_id" {
   description = "EC2 Transit Gateway Route Table identifier"
-  value       = element(concat(aws_ec2_transit_gateway_route_table.this.*.id, [""]), 0)
+  value       = try(aws_ec2_transit_gateway_route_table.this[0].id, "")
 }
 
 # aws_ec2_transit_gateway_route
 output "ec2_transit_gateway_route_ids" {
   description = "List of EC2 Transit Gateway Route Table identifier combined with destination"
-  value       = aws_ec2_transit_gateway_route.this.*.id
+  value       = aws_ec2_transit_gateway_route.this[*].id
 }
 
 # aws_ec2_transit_gateway_vpc_attachment
@@ -82,11 +82,11 @@ output "ec2_transit_gateway_route_table_propagation" {
 # aws_ram_resource_share
 output "ram_resource_share_id" {
   description = "The Amazon Resource Name (ARN) of the resource share"
-  value       = element(concat(aws_ram_resource_share.this.*.id, [""]), 0)
+  value       = try(aws_ram_resource_share.this[0].id, "")
 }
 
 # aws_ram_principal_association
 output "ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
-  value       = element(concat(aws_ram_principal_association.this.*.id, [""]), 0)
+  value       = try(aws_ram_principal_association.this[0].id, "")
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,10 @@
-# aws_ec2_transit_gateway
+################################################################################
+# Transit Gateway
+################################################################################
+
 output "ec2_transit_gateway_arn" {
   description = "EC2 Transit Gateway Amazon Resource Name (ARN)"
   value       = try(aws_ec2_transit_gateway.this[0].arn, "")
-}
-
-output "ec2_transit_gateway_association_default_route_table_id" {
-  description = "Identifier of the default association route table"
-  value       = try(aws_ec2_transit_gateway.this[0].association_default_route_table_id, "")
 }
 
 output "ec2_transit_gateway_id" {
@@ -19,34 +17,20 @@ output "ec2_transit_gateway_owner_id" {
   value       = try(aws_ec2_transit_gateway.this[0].owner_id, "")
 }
 
+output "ec2_transit_gateway_association_default_route_table_id" {
+  description = "Identifier of the default association route table"
+  value       = try(aws_ec2_transit_gateway.this[0].association_default_route_table_id, "")
+}
+
 output "ec2_transit_gateway_propagation_default_route_table_id" {
   description = "Identifier of the default propagation route table"
   value       = try(aws_ec2_transit_gateway.this[0].propagation_default_route_table_id, "")
 }
 
-# aws_ec2_transit_gateway_route_table
-output "ec2_transit_gateway_route_table_default_association_route_table" {
-  description = "Boolean whether this is the default association route table for the EC2 Transit Gateway"
-  value       = try(aws_ec2_transit_gateway_route_table.this[0].default_association_route_table, "")
-}
+################################################################################
+# VPC Attachment
+################################################################################
 
-output "ec2_transit_gateway_route_table_default_propagation_route_table" {
-  description = "Boolean whether this is the default propagation route table for the EC2 Transit Gateway"
-  value       = try(aws_ec2_transit_gateway_route_table.this[0].default_propagation_route_table, "")
-}
-
-output "ec2_transit_gateway_route_table_id" {
-  description = "EC2 Transit Gateway Route Table identifier"
-  value       = try(aws_ec2_transit_gateway_route_table.this[0].id, "")
-}
-
-# aws_ec2_transit_gateway_route
-output "ec2_transit_gateway_route_ids" {
-  description = "List of EC2 Transit Gateway Route Table identifier combined with destination"
-  value       = aws_ec2_transit_gateway_route.this[*].id
-}
-
-# aws_ec2_transit_gateway_vpc_attachment
 output "ec2_transit_gateway_vpc_attachment_ids" {
   description = "List of EC2 Transit Gateway VPC Attachment identifiers"
   value       = [for k, v in aws_ec2_transit_gateway_vpc_attachment.this : v.id]
@@ -57,7 +41,30 @@ output "ec2_transit_gateway_vpc_attachment" {
   value       = aws_ec2_transit_gateway_vpc_attachment.this
 }
 
-# aws_ec2_transit_gateway_route_table_association
+################################################################################
+# Route Table / Routes
+################################################################################
+
+output "ec2_transit_gateway_route_table_id" {
+  description = "EC2 Transit Gateway Route Table identifier"
+  value       = try(aws_ec2_transit_gateway_route_table.this[0].id, "")
+}
+
+output "ec2_transit_gateway_route_table_default_association_route_table" {
+  description = "Boolean whether this is the default association route table for the EC2 Transit Gateway"
+  value       = try(aws_ec2_transit_gateway_route_table.this[0].default_association_route_table, "")
+}
+
+output "ec2_transit_gateway_route_table_default_propagation_route_table" {
+  description = "Boolean whether this is the default propagation route table for the EC2 Transit Gateway"
+  value       = try(aws_ec2_transit_gateway_route_table.this[0].default_propagation_route_table, "")
+}
+
+output "ec2_transit_gateway_route_ids" {
+  description = "List of EC2 Transit Gateway Route Table identifier combined with destination"
+  value       = aws_ec2_transit_gateway_route.this[*].id
+}
+
 output "ec2_transit_gateway_route_table_association_ids" {
   description = "List of EC2 Transit Gateway Route Table Association identifiers"
   value       = [for k, v in aws_ec2_transit_gateway_route_table_association.this : v.id]
@@ -68,7 +75,6 @@ output "ec2_transit_gateway_route_table_association" {
   value       = aws_ec2_transit_gateway_route_table_association.this
 }
 
-# aws_ec2_transit_gateway_route_table_propagation
 output "ec2_transit_gateway_route_table_propagation_ids" {
   description = "List of EC2 Transit Gateway Route Table Propagation identifiers"
   value       = [for k, v in aws_ec2_transit_gateway_route_table_propagation.this : v.id]
@@ -79,13 +85,15 @@ output "ec2_transit_gateway_route_table_propagation" {
   value       = aws_ec2_transit_gateway_route_table_propagation.this
 }
 
-# aws_ram_resource_share
+################################################################################
+# Resource Access Manager
+################################################################################
+
 output "ram_resource_share_id" {
   description = "The Amazon Resource Name (ARN) of the resource share"
   value       = try(aws_ram_resource_share.this[0].id, "")
 }
 
-# aws_ram_principal_association
 output "ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
   value       = try(aws_ram_principal_association.this[0].id, "")

--- a/variables.tf
+++ b/variables.tf
@@ -1,25 +1,35 @@
-variable "create_tgw" {
-  description = "Controls if TGW should be created (it affects almost all resources)"
-  type        = bool
-  default     = true
-}
-
 variable "name" {
   description = "Name to be used on all the resources as identifier"
   type        = string
   default     = ""
 }
 
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+################################################################################
+# Transit Gateway
+################################################################################
+
+variable "create_tgw" {
+  description = "Controls if TGW should be created (it affects almost all resources)"
+  type        = bool
+  default     = true
+}
+
+variable "description" {
+  description = "Description of the EC2 Transit Gateway"
+  type        = string
+  default     = null
+}
+
 variable "amazon_side_asn" {
   description = "The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the TGW is created with the current default Amazon ASN."
   type        = string
   default     = "64512"
-}
-
-variable "enable_auto_accept_shared_attachments" {
-  description = "Whether resource attachment requests are automatically accepted"
-  type        = bool
-  default     = false
 }
 
 variable "enable_default_route_table_association" {
@@ -34,16 +44,10 @@ variable "enable_default_route_table_propagation" {
   default     = true
 }
 
-variable "description" {
-  description = "Description of the EC2 Transit Gateway"
-  type        = string
-  default     = null
-}
-
-variable "enable_dns_support" {
-  description = "Should be true to enable DNS support in the TGW"
+variable "enable_auto_accept_shared_attachments" {
+  description = "Whether resource attachment requests are automatically accepted"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "enable_vpn_ecmp_support" {
@@ -52,35 +56,14 @@ variable "enable_vpn_ecmp_support" {
   default     = true
 }
 
-# VPC attachments
-variable "vpc_attachments" {
-  description = "Maps of maps of VPC details to attach to TGW. Type 'any' to disable type validation by Terraform."
-  type        = any
-  default     = {}
-}
-
-# TGW Route Table association and propagation
-variable "transit_gateway_route_table_id" {
-  description = "Identifier of EC2 Transit Gateway Route Table to use with the Target Gateway when reusing it between multiple TGWs"
-  type        = string
-  default     = null
-}
-
-# Tags
-variable "tags" {
-  description = "A map of tags to add to all resources"
-  type        = map(string)
-  default     = {}
+variable "enable_dns_support" {
+  description = "Should be true to enable DNS support in the TGW"
+  type        = bool
+  default     = true
 }
 
 variable "tgw_tags" {
   description = "Additional tags for the TGW"
-  type        = map(string)
-  default     = {}
-}
-
-variable "tgw_route_table_tags" {
-  description = "Additional tags for the TGW route table"
   type        = map(string)
   default     = {}
 }
@@ -91,13 +74,42 @@ variable "tgw_default_route_table_tags" {
   default     = {}
 }
 
+################################################################################
+# VPC Attachment
+################################################################################
+
+variable "vpc_attachments" {
+  description = "Maps of maps of VPC details to attach to TGW. Type 'any' to disable type validation by Terraform."
+  type        = any
+  default     = {}
+}
+
 variable "tgw_vpc_attachment_tags" {
   description = "Additional tags for VPC attachments"
   type        = map(string)
   default     = {}
 }
 
-# TGW resource sharing
+################################################################################
+# Route Table / Routes
+################################################################################
+
+variable "transit_gateway_route_table_id" {
+  description = "Identifier of EC2 Transit Gateway Route Table to use with the Target Gateway when reusing it between multiple TGWs"
+  type        = string
+  default     = null
+}
+
+variable "tgw_route_table_tags" {
+  description = "Additional tags for the TGW route table"
+  type        = map(string)
+  default     = {}
+}
+
+################################################################################
+# Resource Access Manager
+################################################################################
+
 variable "share_tgw" {
   description = "Whether to share your transit gateway with other accounts"
   type        = bool
@@ -116,12 +128,6 @@ variable "ram_allow_external_principals" {
   default     = false
 }
 
-variable "ram_tags" {
-  description = "Additional tags for the RAM"
-  type        = map(string)
-  default     = {}
-}
-
 variable "ram_principals" {
   description = "A list of principals to share TGW with. Possible values are an AWS account ID, an AWS Organizations Organization ARN, or an AWS Organizations Organization Unit ARN"
   type        = list(string)
@@ -132,4 +138,10 @@ variable "ram_resource_share_arn" {
   description = "ARN of RAM resource share"
   type        = string
   default     = ""
+}
+
+variable "ram_tags" {
+  description = "Additional tags for the RAM"
+  type        = map(string)
+  default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.15.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.15"
+    }
   }
 }


### PR DESCRIPTION
## Description
- Update Terraform minimum supported version to `v0.13.1`
- Fix cross-account TGW sharing via RAM (see https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/commit/120533a498639d79b32586b25edce6151694b9d9)
- Re-order tag values to allow resource specific tags to override `Name` tag used (this change should be a no-op for users)
- Formatting and code organization updates to align with current standards
- Replace use of `lookup()` with `try()`
- Fix examples to use VPC and subnets created by the examples rather than creating the VPCs but relying on the users account default VPC
- Replace deprecated `aws_subnet_ids` data source in examples with `aws_subnets`
- Update provider required version schema to use current format
- Remove example data sources and use module outputs directly

## Motivation and Context
- To align with current standards
- Closes #67
- Relates to #46
- Relates to #47
- Relates to #56
- Relates to #61

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Validated before/after of `examples/complete`
	- Unable to validate `examples/multi-account` due to issue stated in #67 (exists prior to this change so unable to apply)