### PR TITLE
feat: Add support for transit gateway CIDR blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ module "vpc" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.4 |
 
 ## Modules
 
@@ -102,7 +102,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the TGW is created with the current default Amazon ASN. | `string` | `"64512"` | no |
+| <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the TGW is created with the current default Amazon ASN. | `string` | `null` | no |
 | <a name="input_create_tgw"></a> [create\_tgw](#input\_create\_tgw) | Controls if TGW should be created (it affects almost all resources) | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of the EC2 Transit Gateway | `string` | `null` | no |
 | <a name="input_enable_auto_accept_shared_attachments"></a> [enable\_auto\_accept\_shared\_attachments](#input\_enable\_auto\_accept\_shared\_attachments) | Whether resource attachment requests are automatically accepted | `bool` | `false` | no |
@@ -122,6 +122,8 @@ No modules.
 | <a name="input_tgw_route_table_tags"></a> [tgw\_route\_table\_tags](#input\_tgw\_route\_table\_tags) | Additional tags for the TGW route table | `map(string)` | `{}` | no |
 | <a name="input_tgw_tags"></a> [tgw\_tags](#input\_tgw\_tags) | Additional tags for the TGW | `map(string)` | `{}` | no |
 | <a name="input_tgw_vpc_attachment_tags"></a> [tgw\_vpc\_attachment\_tags](#input\_tgw\_vpc\_attachment\_tags) | Additional tags for VPC attachments | `map(string)` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create, update, and delete timeout configurations for the transit gateway | `map(string)` | `{}` | no |
+| <a name="input_transit_gateway_cidr_blocks"></a> [transit\_gateway\_cidr\_blocks](#input\_transit\_gateway\_cidr\_blocks) | One or more IPv4 or IPv6 CIDR blocks for the transit gateway. Must be a size /24 CIDR block or larger for IPv4, or a size /64 CIDR block or larger for IPv6 | `list(string)` | `[]` | no |
 | <a name="input_transit_gateway_route_table_id"></a> [transit\_gateway\_route\_table\_id](#input\_transit\_gateway\_route\_table\_id) | Identifier of EC2 Transit Gateway Route Table to use with the Target Gateway when reusing it between multiple TGWs | `string` | `null` | no |
 | <a name="input_vpc_attachments"></a> [vpc\_attachments](#input\_vpc\_attachments) | Maps of maps of VPC details to attach to TGW. Type 'any' to disable type validation by Terraform. | `any` | `{}` | no |
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4 |
 
 ## Providers
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -24,6 +24,8 @@ module "tgw" {
   description     = "My TGW shared with several other AWS accounts"
   amazon_side_asn = 64532
 
+  transit_gateway_cidr_blocks = ["10.99.0.0/24"]
+
   # When "true" there is no need for RAM resources if using multiple AWS accounts
   enable_auto_accept_shared_attachments = true
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 4.4"
     }
   }
 }

--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4 |
 
 ## Providers
 

--- a/examples/multi-account/versions.tf
+++ b/examples/multi-account/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 4.4"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,13 @@ resource "aws_ec2_transit_gateway" "this" {
   auto_accept_shared_attachments  = var.enable_auto_accept_shared_attachments ? "enable" : "disable"
   vpn_ecmp_support                = var.enable_vpn_ecmp_support ? "enable" : "disable"
   dns_support                     = var.enable_dns_support ? "enable" : "disable"
+  transit_gateway_cidr_blocks     = var.transit_gateway_cidr_blocks
+
+  timeouts {
+    create = try(var.timeouts.create, null)
+    update = try(var.timeouts.update, null)
+    delete = try(var.timeouts.delete, null)
+  }
 
   tags = merge(
     var.tags,

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "description" {
 variable "amazon_side_asn" {
   description = "The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the TGW is created with the current default Amazon ASN."
   type        = string
-  default     = "64512"
+  default     = null
 }
 
 variable "enable_default_route_table_association" {
@@ -60,6 +60,18 @@ variable "enable_dns_support" {
   description = "Should be true to enable DNS support in the TGW"
   type        = bool
   default     = true
+}
+
+variable "transit_gateway_cidr_blocks" {
+  description = "One or more IPv4 or IPv6 CIDR blocks for the transit gateway. Must be a size /24 CIDR block or larger for IPv4, or a size /64 CIDR block or larger for IPv6"
+  type        = list(string)
+  default     = []
+}
+
+variable "timeouts" {
+  description = "Create, update, and delete timeout configurations for the transit gateway"
+  type        = map(string)
+  default     = {}
 }
 
 variable "tgw_tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 4.4"
     }
   }
 }


### PR DESCRIPTION
## Description
- Add support for transit gateway CIDR blocks
- Change `var.amazon_side_asn` default to `null` which defaults to `"64512"`
- Add configurable timeouts block to transit gateway

## Motivation and Context
- New functionality that was recently released
- Closes #66

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Tested on `examples/complete`