### PR TITLE
feat: More control over routes and route tables 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -117,22 +117,22 @@ resource "aws_route" "this" {
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {
   for_each = {
-    for k, v in var.vpc_attachments : k => v if var.create_tgw && try(v.transit_gateway_default_route_table_association, true) != true
+    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_association, true) != true
   }
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = var.create_tgw ? aws_ec2_transit_gateway_route_table.this[0].id : try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id)
+  transit_gateway_route_table_id = try(try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id), aws_ec2_transit_gateway_route_table.this[0].id)
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
   for_each = {
-    for k, v in var.vpc_attachments : k => v if var.create_tgw && try(v.transit_gateway_default_route_table_propagation, true) != true
+    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_propagation, true) != true
   }
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = var.create_tgw ? aws_ec2_transit_gateway_route_table.this[0].id : try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id)
+  transit_gateway_route_table_id = try(try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id), aws_ec2_transit_gateway_route_table.this[0].id)
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -117,22 +117,22 @@ resource "aws_route" "this" {
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {
   for_each = {
-    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_association, true) != true
+    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_association, true) != true && try(v.associate_tgw_rtb, true)
   }
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id)
+  transit_gateway_route_table_id = var.create_tgw ? try(each.value.transit_gateway_association_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id) : try(each.value.transit_gateway_association_route_table_id, each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id)
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
   for_each = {
-    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_propagation, true) != true
+    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_propagation, true) != true && try(v.propagaate_tgw_rtb, true)
   }
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id)
+  transit_gateway_route_table_id = var.create_tgw ? try(each.value.transit_gateway_propagation_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id) : try(each.value.transit_gateway_propagation_route_table_id, each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id)
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ locals {
       for rtb_id in try(v.vpc_route_table_ids, []) : {
         rtb_id = rtb_id
         cidr   = v.tgw_destination_cidr
-        tgw_id = v.tgw_id
+        tgw_id = try(v.tgw_id, null)
       }
     ]
   ])

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "this" {
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = try(try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id), aws_ec2_transit_gateway_route_table.this[0].id)
+  transit_gateway_route_table_id = try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id)
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
@@ -132,7 +132,7 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = try(try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id), aws_ec2_transit_gateway_route_table.this[0].id)
+  transit_gateway_route_table_id = try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id, aws_ec2_transit_gateway_route_table.this[0].id)
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "this" {
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
   for_each = {
-    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_propagation, true) != true && try(v.propagaate_tgw_rtb, true)
+    for k, v in var.vpc_attachments : k => v if try(v.transit_gateway_default_route_table_propagation, true) != true && try(v.propagate_tgw_rtb, true)
   }
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # List of maps with key and route values
   vpc_attachments_with_routes = chunklist(flatten([
-    for k, v in var.vpc_attachments : setproduct([{ key = k }], v.tgw_routes) if var.create_tgw && can(v.tgw_routes)
+    for k, v in var.vpc_attachments : setproduct([{ key = k }], v.tgw_routes) if can(v.tgw_routes)
   ]), 2)
 
   tgw_default_route_table_tags_merged = merge(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Allow non-create to add routes
* Allow user provided association and propag. tables

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In order to provide more granular control of the route tables and associations this change allows the users to provide their own route tables.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
