### PR TITLE
feat: Custom VPC Attachment Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ module "tgw" {
 
   vpc_attachments = {
     vpc = {
+      name         = "my-vpc"
       vpc_id       = module.vpc.vpc_id
       subnet_ids   = module.vpc.private_subnets
       dns_support  = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -34,6 +34,7 @@ module "tgw" {
 
   vpc_attachments = {
     vpc1 = {
+      name         = "VPC 1"
       vpc_id       = module.vpc1.vpc_id
       subnet_ids   = module.vpc1.private_subnets
       dns_support  = true

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 
   tags = merge(
     var.tags,
-    { Name = var.name },
+    { Name = try(each.value.name, var.name) },
     var.tgw_vpc_attachment_tags,
   )
 }


### PR DESCRIPTION
## Description

This PR adds support for specifying a custom name for VPC attachments. Currently, this module tags all the attachments with the name of the Transit Gateway. This PR allows consumers to optionally add a `name` key to the existing `vpc_attachments` map of maps. If no name is supplied, it uses the name of the TGW as before.

## Motivation and Context

The motivation behind opening this PR was to make it easier to distinguish VPC attachments by way of custom names.

## Breaking Changes

This is a backwards-compatible change, however if for some reason someone already had a `name` key in their VPC attachment definitions, then this would result in the attachment name being changed.

## How Has This Been Tested?
- [x ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
