### PR TITLE
fix: Update routes when doing a vpc attachment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ locals {
       for rtb_id in try(v.vpc_route_table_ids, []) : {
         rtb_id = rtb_id
         cidr   = v.tgw_destination_cidr
+        tgw_id = v.tgw_id
       }
     ]
   ])
@@ -109,11 +110,11 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for x in local.vpc_route_table_destination_cidr : x.rtb_id => x.cidr }
+  for_each = { for route in local.vpc_route_table_destination_cidr : route.rtb_id => route }
 
   route_table_id         = each.key
-  destination_cidr_block = each.value
-  transit_gateway_id     = aws_ec2_transit_gateway.this[0].id
+  destination_cidr_block = each.value.cidr
+  transit_gateway_id     = var.create_tgw ? aws_ec2_transit_gateway.this[0].id : each.value.tgw_id
 }
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ locals {
       for rtb_id in try(v.vpc_route_table_ids, []) : {
         rtb_id = rtb_id
         cidr   = v.tgw_destination_cidr
-        tgw_id = v.tgw_id
+        tgw_id = !var.create_tgw ? v.tgw_id : null
       }
     ]
   ])


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The VPC attachment block supports adding routes to an existing route table but that only works when you are creating a transit gateway. When you are just attaching a VPC to a shared gateway it doesn't work as it only looks at the Id of the internal resource.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change would allow to update route tables when attaching VPCs to a shared transit gateway by taking parsing the tgw_id attribute as well. Logic is replicated from the `aws_ec2_transit_gateway_vpc_attachment` resource.
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Not a breaking change.
## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s).
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects. It was tested with similar implementation to the multi-account setup.
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
