### PR TITLE
feat: Add attachment name to Name tag as suffix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 
   tags = merge(
     var.tags,
-    { Name = var.name },
+    { Name = "${var.name}-${each.key}" },
     var.tgw_vpc_attachment_tags,
   )
 }


### PR DESCRIPTION
## Description

Module creates server TWG attachments and all with the same `var.name` in `Name` tag. A small improvement might be to add an attachment name as a suffix to `Name` tag.

## Breaking Changes

I'm not sure if changing existing tags is a breaking change or not. At least the common name might be added to `var.tgw_vpc_attachment_tags` if new style is not acceptable by someone.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
