### PR TITLE
fix: Change count for for_each on ram_principal_association due resource recreation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -161,9 +161,9 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  count = var.create_tgw && var.share_tgw ? length(var.ram_principals) : 0
+  for_each = var.create_tgw && var.share_tgw ? toset(var.ram_principals) : []
 
-  principal          = var.ram_principals[count.index]
+  principal          = each.value
   resource_share_arn = aws_ram_resource_share.this[0].arn
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,7 @@
 locals {
+  # Store the list of principals and convert to set
+  ram_principals = var.create_tgw && var.share_tgw ? toset(var.ram_principals) : []
+
   # List of maps with key and route values
   vpc_attachments_with_routes = chunklist(flatten([
     for k, v in var.vpc_attachments : setproduct([{ key = k }], v.tgw_routes) if var.create_tgw && can(v.tgw_routes)
@@ -161,7 +164,7 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  for_each = var.create_tgw && var.share_tgw ? toset(var.ram_principals) : []
+  for_each = local.ram_principals
 
   principal          = each.value
   resource_share_arn = aws_ram_resource_share.this[0].arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -96,5 +96,5 @@ output "ram_resource_share_id" {
 
 output "ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
-  value       = try(aws_ram_principal_association.this[0].id, "")
+  value       = [for k, v in aws_ram_principal_association.this : v.id]
 }


### PR DESCRIPTION
## Description
Change `count` for `for_each` on `aws_ram_principal_association` due resource recreation.

## Motivation and Context
In order to avoid recreation of the resource `aws_ram_principal_association` everytime that a principal is removed or inserted in the middle of the list, it's necessary to change `count` for `for_each` loop. 

## Breaking Changes
The meta-argument `count` use indices to organize the list, for instance `aws_ram_principal_association.this["0"]`. 
The meta-argument `for_each`uses "key, value" to organize it, for instance `aws_ram_principal_association.this["01234567890123"]` where `01234567890123` will be the principal account ID for this case.
So due these differences it will cause a recreation of all existing `aws_ram_principal_association` resources and the people who use RAM for share the TGW will need to run `terraform state mv` in order to avoid this recreation.

## How Has This Been Tested?

It has been tested using the module with input `share_tgw = true` by analysing the `plan` and outputs after `apply`.

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
