### PR TITLE
feat: Add peering attachment and accepter resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ No modules.
 |------|------|
 | [aws_ec2_tag.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_ec2_transit_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway) | resource |
+| [aws_ec2_transit_gateway_peering_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment) | resource |
+| [aws_ec2_transit_gateway_peering_attachment_accepter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment_accepter) | resource |
 | [aws_ec2_transit_gateway_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
 | [aws_ec2_transit_gateway_route_table.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table) | resource |
 | [aws_ec2_transit_gateway_route_table_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
@@ -112,6 +114,11 @@ No modules.
 | <a name="input_enable_mutlicast_support"></a> [enable\_mutlicast\_support](#input\_enable\_mutlicast\_support) | Whether multicast support is enabled | `bool` | `false` | no |
 | <a name="input_enable_vpn_ecmp_support"></a> [enable\_vpn\_ecmp\_support](#input\_enable\_vpn\_ecmp\_support) | Whether VPN Equal Cost Multipath Protocol support is enabled | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier | `string` | `""` | no |
+| <a name="input_peer_account_id"></a> [peer\_account\_id](#input\_peer\_account\_id) | Identifier of the AWS account that owns the EC2 TGW peering. | `map(string)` | `{}` | no |
+| <a name="input_peer_region"></a> [peer\_region](#input\_peer\_region) | Region of EC2 Transit Gateway to peer with. | `map(string)` | `{}` | no |
+| <a name="input_peer_transit_gateway_id"></a> [peer\_transit\_gateway\_id](#input\_peer\_transit\_gateway\_id) | Identifier of EC2 Transit Gateway to peer with. | `map(string)` | `{}` | no |
+| <a name="input_peering_attachment_accepters"></a> [peering\_attachment\_accepters](#input\_peering\_attachment\_accepters) | Maps of maps of Peering Attachment Accepters details. Type 'any' to disable type validation by Terraform. | `any` | `{}` | no |
+| <a name="input_peering_attachments"></a> [peering\_attachments](#input\_peering\_attachments) | Maps of maps of Peering Attachments details. Type 'any' to disable type validation by Terraform. | `any` | `{}` | no |
 | <a name="input_ram_allow_external_principals"></a> [ram\_allow\_external\_principals](#input\_ram\_allow\_external\_principals) | Indicates whether principals outside your organization can be associated with a resource share. | `bool` | `false` | no |
 | <a name="input_ram_name"></a> [ram\_name](#input\_ram\_name) | The name of the resource share of TGW | `string` | `""` | no |
 | <a name="input_ram_principals"></a> [ram\_principals](#input\_ram\_principals) | A list of principals to share TGW with. Possible values are an AWS account ID, an AWS Organizations Organization ARN, or an AWS Organizations Organization Unit ARN | `list(string)` | `[]` | no |
@@ -120,11 +127,14 @@ No modules.
 | <a name="input_share_tgw"></a> [share\_tgw](#input\_share\_tgw) | Whether to share your transit gateway with other accounts | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_tgw_default_route_table_tags"></a> [tgw\_default\_route\_table\_tags](#input\_tgw\_default\_route\_table\_tags) | Additional tags for the Default TGW route table | `map(string)` | `{}` | no |
+| <a name="input_tgw_peering_attachment_accepter_tags"></a> [tgw\_peering\_attachment\_accepter\_tags](#input\_tgw\_peering\_attachment\_accepter\_tags) | Additional tags for Peering Attachment Accepters. | `map(string)` | `{}` | no |
+| <a name="input_tgw_peering_attachment_tags"></a> [tgw\_peering\_attachment\_tags](#input\_tgw\_peering\_attachment\_tags) | Additional tags for Peering attachments. | `map(string)` | `{}` | no |
 | <a name="input_tgw_route_table_tags"></a> [tgw\_route\_table\_tags](#input\_tgw\_route\_table\_tags) | Additional tags for the TGW route table | `map(string)` | `{}` | no |
 | <a name="input_tgw_tags"></a> [tgw\_tags](#input\_tgw\_tags) | Additional tags for the TGW | `map(string)` | `{}` | no |
 | <a name="input_tgw_vpc_attachment_tags"></a> [tgw\_vpc\_attachment\_tags](#input\_tgw\_vpc\_attachment\_tags) | Additional tags for VPC attachments | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create, update, and delete timeout configurations for the transit gateway | `map(string)` | `{}` | no |
 | <a name="input_transit_gateway_cidr_blocks"></a> [transit\_gateway\_cidr\_blocks](#input\_transit\_gateway\_cidr\_blocks) | One or more IPv4 or IPv6 CIDR blocks for the transit gateway. Must be a size /24 CIDR block or larger for IPv4, or a size /64 CIDR block or larger for IPv6 | `list(string)` | `[]` | no |
+| <a name="input_transit_gateway_peering_attachment_id"></a> [transit\_gateway\_peering\_attachment\_id](#input\_transit\_gateway\_peering\_attachment\_id) | The ID of the EC2 Transit Gateway Peering Attachment to manage. | `string` | `""` | no |
 | <a name="input_transit_gateway_route_table_id"></a> [transit\_gateway\_route\_table\_id](#input\_transit\_gateway\_route\_table\_id) | Identifier of EC2 Transit Gateway Route Table to use with the Target Gateway when reusing it between multiple TGWs | `string` | `null` | no |
 | <a name="input_vpc_attachments"></a> [vpc\_attachments](#input\_vpc\_attachments) | Maps of maps of VPC details to attach to TGW. Type 'any' to disable type validation by Terraform. | `any` | `{}` | no |
 
@@ -136,6 +146,10 @@ No modules.
 | <a name="output_ec2_transit_gateway_association_default_route_table_id"></a> [ec2\_transit\_gateway\_association\_default\_route\_table\_id](#output\_ec2\_transit\_gateway\_association\_default\_route\_table\_id) | Identifier of the default association route table |
 | <a name="output_ec2_transit_gateway_id"></a> [ec2\_transit\_gateway\_id](#output\_ec2\_transit\_gateway\_id) | EC2 Transit Gateway identifier |
 | <a name="output_ec2_transit_gateway_owner_id"></a> [ec2\_transit\_gateway\_owner\_id](#output\_ec2\_transit\_gateway\_owner\_id) | Identifier of the AWS account that owns the EC2 Transit Gateway |
+| <a name="output_ec2_transit_gateway_peering_accepter_attachment"></a> [ec2\_transit\_gateway\_peering\_accepter\_attachment](#output\_ec2\_transit\_gateway\_peering\_accepter\_attachment) | Map of EC2 Transit Gateway Peering Attachment Accepter attributes |
+| <a name="output_ec2_transit_gateway_peering_attachment"></a> [ec2\_transit\_gateway\_peering\_attachment](#output\_ec2\_transit\_gateway\_peering\_attachment) | Map of EC2 Transit Gateway Peering Attachment attributes |
+| <a name="output_ec2_transit_gateway_peering_attachment_accepter_ids"></a> [ec2\_transit\_gateway\_peering\_attachment\_accepter\_ids](#output\_ec2\_transit\_gateway\_peering\_attachment\_accepter\_ids) | List of EC2 Transit Gateway Peering Attachment Accepter identifiers |
+| <a name="output_ec2_transit_gateway_peering_attachment_ids"></a> [ec2\_transit\_gateway\_peering\_attachment\_ids](#output\_ec2\_transit\_gateway\_peering\_attachment\_ids) | List of EC2 Transit Gateway Peering Attachment identifiers |
 | <a name="output_ec2_transit_gateway_propagation_default_route_table_id"></a> [ec2\_transit\_gateway\_propagation\_default\_route\_table\_id](#output\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id) | Identifier of the default propagation route table |
 | <a name="output_ec2_transit_gateway_route_ids"></a> [ec2\_transit\_gateway\_route\_ids](#output\_ec2\_transit\_gateway\_route\_ids) | List of EC2 Transit Gateway Route Table identifier combined with destination |
 | <a name="output_ec2_transit_gateway_route_table_association"></a> [ec2\_transit\_gateway\_route\_table\_association](#output\_ec2\_transit\_gateway\_route\_table\_association) | Map of EC2 Transit Gateway Route Table Association attributes |

--- a/README.md
+++ b/README.md
@@ -114,9 +114,6 @@ No modules.
 | <a name="input_enable_mutlicast_support"></a> [enable\_mutlicast\_support](#input\_enable\_mutlicast\_support) | Whether multicast support is enabled | `bool` | `false` | no |
 | <a name="input_enable_vpn_ecmp_support"></a> [enable\_vpn\_ecmp\_support](#input\_enable\_vpn\_ecmp\_support) | Whether VPN Equal Cost Multipath Protocol support is enabled | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier | `string` | `""` | no |
-| <a name="input_peer_account_id"></a> [peer\_account\_id](#input\_peer\_account\_id) | Identifier of the AWS account that owns the EC2 TGW peering. | `map(string)` | `{}` | no |
-| <a name="input_peer_region"></a> [peer\_region](#input\_peer\_region) | Region of EC2 Transit Gateway to peer with. | `map(string)` | `{}` | no |
-| <a name="input_peer_transit_gateway_id"></a> [peer\_transit\_gateway\_id](#input\_peer\_transit\_gateway\_id) | Identifier of EC2 Transit Gateway to peer with. | `map(string)` | `{}` | no |
 | <a name="input_peering_attachment_accepters"></a> [peering\_attachment\_accepters](#input\_peering\_attachment\_accepters) | Maps of maps of Peering Attachment Accepters details. Type 'any' to disable type validation by Terraform. | `any` | `{}` | no |
 | <a name="input_peering_attachments"></a> [peering\_attachments](#input\_peering\_attachments) | Maps of maps of Peering Attachments details. Type 'any' to disable type validation by Terraform. | `any` | `{}` | no |
 | <a name="input_ram_allow_external_principals"></a> [ram\_allow\_external\_principals](#input\_ram\_allow\_external\_principals) | Indicates whether principals outside your organization can be associated with a resource share. | `bool` | `false` | no |
@@ -134,7 +131,6 @@ No modules.
 | <a name="input_tgw_vpc_attachment_tags"></a> [tgw\_vpc\_attachment\_tags](#input\_tgw\_vpc\_attachment\_tags) | Additional tags for VPC attachments | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create, update, and delete timeout configurations for the transit gateway | `map(string)` | `{}` | no |
 | <a name="input_transit_gateway_cidr_blocks"></a> [transit\_gateway\_cidr\_blocks](#input\_transit\_gateway\_cidr\_blocks) | One or more IPv4 or IPv6 CIDR blocks for the transit gateway. Must be a size /24 CIDR block or larger for IPv4, or a size /64 CIDR block or larger for IPv6 | `list(string)` | `[]` | no |
-| <a name="input_transit_gateway_peering_attachment_id"></a> [transit\_gateway\_peering\_attachment\_id](#input\_transit\_gateway\_peering\_attachment\_id) | The ID of the EC2 Transit Gateway Peering Attachment to manage. | `string` | `""` | no |
 | <a name="input_transit_gateway_route_table_id"></a> [transit\_gateway\_route\_table\_id](#input\_transit\_gateway\_route\_table\_id) | Identifier of EC2 Transit Gateway Route Table to use with the Target Gateway when reusing it between multiple TGWs | `string` | `null` | no |
 | <a name="input_vpc_attachments"></a> [vpc\_attachments](#input\_vpc\_attachments) | Maps of maps of VPC details to attach to TGW. Type 'any' to disable type validation by Terraform. | `any` | `{}` | no |
 

--- a/examples/inter-region/README.md
+++ b/examples/inter-region/README.md
@@ -1,0 +1,67 @@
+# Complete AWS Transit Gateway example
+
+Configuration in this directory creates an AWS Transit Gateway in two regions, attaches a VPC to them and creates a peering connection between them.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_tgw"></a> [tgw](#module\_tgw) | ../../ | n/a |
+| <a name="module_tgw_peer"></a> [tgw\_peer](#module\_tgw\_peer) | ../../ | n/a |
+| <a name="module_vpc1"></a> [vpc1](#module\_vpc1) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ec2_transit_gateway_arn"></a> [ec2\_transit\_gateway\_arn](#output\_ec2\_transit\_gateway\_arn) | EC2 Transit Gateway Amazon Resource Name (ARN) |
+| <a name="output_ec2_transit_gateway_association_default_route_table_id"></a> [ec2\_transit\_gateway\_association\_default\_route\_table\_id](#output\_ec2\_transit\_gateway\_association\_default\_route\_table\_id) | Identifier of the default association route table |
+| <a name="output_ec2_transit_gateway_id"></a> [ec2\_transit\_gateway\_id](#output\_ec2\_transit\_gateway\_id) | EC2 Transit Gateway identifier |
+| <a name="output_ec2_transit_gateway_owner_id"></a> [ec2\_transit\_gateway\_owner\_id](#output\_ec2\_transit\_gateway\_owner\_id) | Identifier of the AWS account that owns the EC2 Transit Gateway |
+| <a name="output_ec2_transit_gateway_propagation_default_route_table_id"></a> [ec2\_transit\_gateway\_propagation\_default\_route\_table\_id](#output\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id) | Identifier of the default propagation route table |
+| <a name="output_ec2_transit_gateway_route_ids"></a> [ec2\_transit\_gateway\_route\_ids](#output\_ec2\_transit\_gateway\_route\_ids) | List of EC2 Transit Gateway Route Table identifier combined with destination |
+| <a name="output_ec2_transit_gateway_route_table_association"></a> [ec2\_transit\_gateway\_route\_table\_association](#output\_ec2\_transit\_gateway\_route\_table\_association) | Map of EC2 Transit Gateway Route Table Association attributes |
+| <a name="output_ec2_transit_gateway_route_table_association_ids"></a> [ec2\_transit\_gateway\_route\_table\_association\_ids](#output\_ec2\_transit\_gateway\_route\_table\_association\_ids) | List of EC2 Transit Gateway Route Table Association identifiers |
+| <a name="output_ec2_transit_gateway_route_table_default_association_route_table"></a> [ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table](#output\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table) | Boolean whether this is the default association route table for the EC2 Transit Gateway |
+| <a name="output_ec2_transit_gateway_route_table_default_propagation_route_table"></a> [ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table](#output\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table) | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
+| <a name="output_ec2_transit_gateway_route_table_id"></a> [ec2\_transit\_gateway\_route\_table\_id](#output\_ec2\_transit\_gateway\_route\_table\_id) | EC2 Transit Gateway Route Table identifier |
+| <a name="output_ec2_transit_gateway_route_table_propagation"></a> [ec2\_transit\_gateway\_route\_table\_propagation](#output\_ec2\_transit\_gateway\_route\_table\_propagation) | Map of EC2 Transit Gateway Route Table Propagation attributes |
+| <a name="output_ec2_transit_gateway_route_table_propagation_ids"></a> [ec2\_transit\_gateway\_route\_table\_propagation\_ids](#output\_ec2\_transit\_gateway\_route\_table\_propagation\_ids) | List of EC2 Transit Gateway Route Table Propagation identifiers |
+| <a name="output_ec2_transit_gateway_vpc_attachment"></a> [ec2\_transit\_gateway\_vpc\_attachment](#output\_ec2\_transit\_gateway\_vpc\_attachment) | Map of EC2 Transit Gateway VPC Attachment attributes |
+| <a name="output_ec2_transit_gateway_vpc_attachment_ids"></a> [ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
+| <a name="output_ram_principal_association_id"></a> [ram\_principal\_association\_id](#output\_ram\_principal\_association\_id) | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
+| <a name="output_ram_resource_share_id"></a> [ram\_resource\_share\_id](#output\_ram\_resource\_share\_id) | The Amazon Resource Name (ARN) of the resource share |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/inter-region/main.tf
+++ b/examples/inter-region/main.tf
@@ -58,8 +58,7 @@ module "tgw" {
 
   peering_attachments = {
     peer_frankfurt = {
-      #peer_account_id         = "307990089504"
-      peer_account_id         = "270382647185"
+      peer_account_id         = "307990089504"
       peer_region             = local.region_peer
       peer_transit_gateway_id = module.tgw_peer.ec2_transit_gateway_id
     }

--- a/examples/inter-region/main.tf
+++ b/examples/inter-region/main.tf
@@ -1,0 +1,156 @@
+provider "aws" {
+  region = local.region
+}
+
+# This provider is required for attachment only installation in another AWS Account
+provider "aws" {
+  region = local.region_peer
+  alias  = "peer"
+}
+
+locals {
+  name        = "ex-tgw-${replace(basename(path.cwd), "_", "-")}"
+  region      = "eu-west-1"
+  region_peer = "eu-central-1"
+
+  tags = {
+    Example    = local.name
+    GithubRepo = "terraform-aws-eks"
+    GithubOrg  = "terraform-aws-transit-gateway"
+  }
+}
+
+################################################################################
+# Transit Gateway Module
+################################################################################
+
+module "tgw" {
+  source = "../../"
+
+  name            = local.name
+  description     = "My TGW in ${local.region} region"
+  amazon_side_asn = 64532
+
+  create_tgw = true
+  share_tgw  = false
+
+  vpc_attachments = {
+    vpc1 = {
+      vpc_id       = module.vpc1.vpc_id
+      subnet_ids   = module.vpc1.private_subnets
+      dns_support  = true
+      ipv6_support = true
+
+      transit_gateway_default_route_table_association = false
+      transit_gateway_default_route_table_propagation = false
+
+      tgw_routes = [
+        {
+          destination_cidr_block = "10.10.0.0/16"
+        },
+        {
+          blackhole              = true
+          destination_cidr_block = "0.0.0.0/0"
+        }
+      ]
+    }
+  }
+
+  peering_attachments = {
+    peer_frankfurt = {
+      #peer_account_id         = "307990089504"
+      peer_account_id         = "270382647185"
+      peer_region             = local.region_peer
+      peer_transit_gateway_id = module.tgw_peer.ec2_transit_gateway_id
+    }
+  }
+
+  tags = local.tags
+}
+
+module "tgw_peer" {
+  source = "../../"
+
+  providers = {
+    aws = aws.peer
+  }
+
+  name            = "${local.name}-peer"
+  description     = "My TGW in ${local.region_peer} region"
+  amazon_side_asn = 64533
+
+  create_tgw = true
+  share_tgw  = false
+
+  vpc_attachments = {
+    vpc2 = {
+      tgw_id       = module.tgw.ec2_transit_gateway_id
+      vpc_id       = module.vpc2.vpc_id
+      subnet_ids   = module.vpc2.private_subnets
+      dns_support  = true
+      ipv6_support = false
+
+      transit_gateway_default_route_table_association = false
+      transit_gateway_default_route_table_propagation = false
+
+      tgw_routes = [
+        {
+          destination_cidr_block = "10.20.0.0/16"
+        },
+        {
+          blackhole              = true
+          destination_cidr_block = "0.0.0.0/0"
+        }
+      ]
+    },
+  }
+
+  peering_attachment_accepters = {
+    peer_ireland = {
+      transit_gateway_peering_attachment_id = module.tgw.ec2_transit_gateway_peering_attachment_ids[0]
+    }
+  }
+
+  tags = local.tags
+}
+
+################################################################################
+# Supporting resources
+################################################################################
+
+module "vpc1" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = "${local.name}-vpc1"
+  cidr = "10.10.0.0/16"
+
+  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  private_subnets = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
+
+  enable_ipv6                                    = true
+  private_subnet_assign_ipv6_address_on_creation = true
+  private_subnet_ipv6_prefixes                   = [0, 1, 2]
+
+  tags = local.tags
+}
+
+
+module "vpc2" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  providers = {
+    aws = aws.peer
+  }
+
+  name = "${local.name}-vpc2"
+  cidr = "10.20.0.0/16"
+
+  azs             = ["${local.region_peer}a", "${local.region_peer}b", "${local.region_peer}c"]
+  private_subnets = ["10.20.1.0/24", "10.20.2.0/24", "10.20.3.0/24"]
+
+  enable_ipv6 = false
+
+  tags = local.tags
+}

--- a/examples/inter-region/outputs.tf
+++ b/examples/inter-region/outputs.tf
@@ -1,0 +1,100 @@
+################################################################################
+# Transit Gateway
+################################################################################
+
+output "ec2_transit_gateway_arn" {
+  description = "EC2 Transit Gateway Amazon Resource Name (ARN)"
+  value       = module.tgw.ec2_transit_gateway_arn
+}
+
+output "ec2_transit_gateway_id" {
+  description = "EC2 Transit Gateway identifier"
+  value       = module.tgw.ec2_transit_gateway_id
+}
+
+output "ec2_transit_gateway_owner_id" {
+  description = "Identifier of the AWS account that owns the EC2 Transit Gateway"
+  value       = module.tgw.ec2_transit_gateway_owner_id
+}
+
+output "ec2_transit_gateway_association_default_route_table_id" {
+  description = "Identifier of the default association route table"
+  value       = module.tgw.ec2_transit_gateway_association_default_route_table_id
+}
+
+output "ec2_transit_gateway_propagation_default_route_table_id" {
+  description = "Identifier of the default propagation route table"
+  value       = module.tgw.ec2_transit_gateway_propagation_default_route_table_id
+}
+
+################################################################################
+# VPC Attachment
+################################################################################
+
+output "ec2_transit_gateway_vpc_attachment_ids" {
+  description = "List of EC2 Transit Gateway VPC Attachment identifiers"
+  value       = module.tgw.ec2_transit_gateway_vpc_attachment_ids
+}
+
+output "ec2_transit_gateway_vpc_attachment" {
+  description = "Map of EC2 Transit Gateway VPC Attachment attributes"
+  value       = module.tgw.ec2_transit_gateway_vpc_attachment
+}
+
+################################################################################
+# Route Table / Routes
+################################################################################
+
+output "ec2_transit_gateway_route_table_id" {
+  description = "EC2 Transit Gateway Route Table identifier"
+  value       = module.tgw.ec2_transit_gateway_route_table_id
+}
+
+output "ec2_transit_gateway_route_table_default_association_route_table" {
+  description = "Boolean whether this is the default association route table for the EC2 Transit Gateway"
+  value       = module.tgw.ec2_transit_gateway_route_table_default_association_route_table
+}
+
+output "ec2_transit_gateway_route_table_default_propagation_route_table" {
+  description = "Boolean whether this is the default propagation route table for the EC2 Transit Gateway"
+  value       = module.tgw.ec2_transit_gateway_route_table_default_propagation_route_table
+}
+
+output "ec2_transit_gateway_route_ids" {
+  description = "List of EC2 Transit Gateway Route Table identifier combined with destination"
+  value       = module.tgw.ec2_transit_gateway_route_ids
+}
+
+output "ec2_transit_gateway_route_table_association_ids" {
+  description = "List of EC2 Transit Gateway Route Table Association identifiers"
+  value       = module.tgw.ec2_transit_gateway_route_table_association_ids
+}
+
+output "ec2_transit_gateway_route_table_association" {
+  description = "Map of EC2 Transit Gateway Route Table Association attributes"
+  value       = module.tgw.ec2_transit_gateway_route_table_association
+}
+
+output "ec2_transit_gateway_route_table_propagation_ids" {
+  description = "List of EC2 Transit Gateway Route Table Propagation identifiers"
+  value       = module.tgw.ec2_transit_gateway_route_table_propagation_ids
+}
+
+output "ec2_transit_gateway_route_table_propagation" {
+  description = "Map of EC2 Transit Gateway Route Table Propagation attributes"
+  value       = module.tgw.ec2_transit_gateway_route_table_propagation
+}
+
+################################################################################
+# Resource Access Manager
+################################################################################
+
+output "ram_resource_share_id" {
+  description = "The Amazon Resource Name (ARN) of the resource share"
+  value       = module.tgw.ram_resource_share_id
+}
+
+output "ram_principal_association_id" {
+  description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
+  value       = module.tgw.ram_principal_association_id
+}

--- a/examples/inter-region/versions.tf
+++ b/examples/inter-region/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.4"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -172,3 +172,38 @@ resource "aws_ram_resource_share_accepter" "this" {
 
   share_arn = var.ram_resource_share_arn
 }
+
+################################################################################
+# Peering Attachment
+################################################################################
+
+resource "aws_ec2_transit_gateway_peering_attachment" "this" {
+  for_each = var.peering_attachments
+
+  transit_gateway_id      = var.create_tgw ? aws_ec2_transit_gateway.this[0].id : each.value.tgw_id
+  peer_account_id         = each.value.peer_account_id
+  peer_region             = each.value.peer_region
+  peer_transit_gateway_id = each.value.peer_transit_gateway_id
+
+  tags = merge(
+    var.tags,
+    { Name = var.name },
+    var.tgw_peering_attachment_tags,
+  )
+}
+
+################################################################################
+# Peering Attachment Accepter
+################################################################################
+
+resource "aws_ec2_transit_gateway_peering_attachment_accepter" "this" {
+  for_each = var.peering_attachment_accepters
+
+  transit_gateway_attachment_id = each.value.transit_gateway_peering_attachment_id
+
+  tags = merge(
+    var.tags,
+    { Name = var.name },
+    var.tgw_peering_attachment_accepter_tags,
+  )
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -98,3 +98,31 @@ output "ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
   value       = try(aws_ram_principal_association.this[0].id, "")
 }
+
+################################################################################
+# Peering Attachment
+################################################################################
+
+output "ec2_transit_gateway_peering_attachment_ids" {
+  description = "List of EC2 Transit Gateway Peering Attachment identifiers"
+  value       = [for k, v in aws_ec2_transit_gateway_peering_attachment.this : v.id]
+}
+
+output "ec2_transit_gateway_peering_attachment" {
+  description = "Map of EC2 Transit Gateway Peering Attachment attributes"
+  value       = aws_ec2_transit_gateway_peering_attachment.this
+}
+
+################################################################################
+# Peering Attachment Accepter
+################################################################################
+
+output "ec2_transit_gateway_peering_attachment_accepter_ids" {
+  description = "List of EC2 Transit Gateway Peering Attachment Accepter identifiers"
+  value       = [for k, v in aws_ec2_transit_gateway_peering_attachment_accepter.this : v.id]
+}
+
+output "ec2_transit_gateway_peering_accepter_attachment" {
+  description = "Map of EC2 Transit Gateway Peering Attachment Accepter attributes"
+  value       = aws_ec2_transit_gateway_peering_attachment_accepter.this
+}

--- a/variables.tf
+++ b/variables.tf
@@ -163,3 +163,59 @@ variable "ram_tags" {
   type        = map(string)
   default     = {}
 }
+
+################################################################################
+# Peering Attachment
+################################################################################
+
+variable "peering_attachments" {
+  description = "Maps of maps of Peering Attachments details. Type 'any' to disable type validation by Terraform."
+  type        = any
+  default     = {}
+}
+
+variable "peer_account_id" {
+  description = "Identifier of the AWS account that owns the EC2 TGW peering."
+  type        = map(string)
+  default     = {}
+}
+
+variable "peer_region" {
+  description = "Region of EC2 Transit Gateway to peer with."
+  type        = map(string)
+  default     = {}
+}
+
+variable "peer_transit_gateway_id" {
+  description = "Identifier of EC2 Transit Gateway to peer with."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tgw_peering_attachment_tags" {
+  description = "Additional tags for Peering attachments."
+  type        = map(string)
+  default     = {}
+}
+
+################################################################################
+# Peering Attachment Accepter
+################################################################################
+
+variable "peering_attachment_accepters" {
+  description = "Maps of maps of Peering Attachment Accepters details. Type 'any' to disable type validation by Terraform."
+  type        = any
+  default     = {}
+}
+
+variable "transit_gateway_peering_attachment_id" {
+  description = "The ID of the EC2 Transit Gateway Peering Attachment to manage."
+  type        = string
+  default     = ""
+}
+
+variable "tgw_peering_attachment_accepter_tags" {
+  description = "Additional tags for Peering Attachment Accepters."
+  type        = map(string)
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -174,24 +174,6 @@ variable "peering_attachments" {
   default     = {}
 }
 
-variable "peer_account_id" {
-  description = "Identifier of the AWS account that owns the EC2 TGW peering."
-  type        = map(string)
-  default     = {}
-}
-
-variable "peer_region" {
-  description = "Region of EC2 Transit Gateway to peer with."
-  type        = map(string)
-  default     = {}
-}
-
-variable "peer_transit_gateway_id" {
-  description = "Identifier of EC2 Transit Gateway to peer with."
-  type        = map(string)
-  default     = {}
-}
-
 variable "tgw_peering_attachment_tags" {
   description = "Additional tags for Peering attachments."
   type        = map(string)
@@ -206,12 +188,6 @@ variable "peering_attachment_accepters" {
   description = "Maps of maps of Peering Attachment Accepters details. Type 'any' to disable type validation by Terraform."
   type        = any
   default     = {}
-}
-
-variable "transit_gateway_peering_attachment_id" {
-  description = "The ID of the EC2 Transit Gateway Peering Attachment to manage."
-  type        = string
-  default     = ""
 }
 
 variable "tgw_peering_attachment_accepter_tags" {


### PR DESCRIPTION
## Description
Add ability to create a peering connection between regions in AWS Transit Gateway

## Motivation and Context
The current state of AWS Transit Gateway module doesn't allow peering two Transit Gateways in different region.
Mentioned in [issue#79](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/79)

## Breaking Changes
No

## How Has This Been Tested?
- [✅] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [✅] I have tested and validated these changes using one or more of the provided `examples/*` projects
   - Tested via new inter-region example
- [✅] I have executed `pre-commit run -a` on my pull request
