### PR TITLE
fix: Use IPv6 CIDR block destination on route when IPv6 support is enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,9 +111,10 @@ resource "aws_ec2_transit_gateway_route" "this" {
 resource "aws_route" "this" {
   for_each = { for x in local.vpc_route_table_destination_cidr : x.rtb_id => x.cidr }
 
-  route_table_id         = each.key
-  destination_cidr_block = each.value
-  transit_gateway_id     = aws_ec2_transit_gateway.this[0].id
+  route_table_id              = each.key
+  destination_cidr_block      = try(each.value.ipv6_support, false) ? null : each.value
+  destination_ipv6_cidr_block = try(each.value.ipv6_support, false) ? each.value : null
+  transit_gateway_id          = aws_ec2_transit_gateway.this[0].id
 }
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {

--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource "aws_route" "this" {
   route_table_id              = each.key
   destination_cidr_block      = try(each.value.ipv6_support, false) ? null : each.value["cidr"]
   destination_ipv6_cidr_block = try(each.value.ipv6_support, false) ? each.value["cidr"] : null
-  transit_gateway_id          = aws_ec2_transit_gateway.this[0].id
+  transit_gateway_id          = each.value["tgw_id"]
 }
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {


### PR DESCRIPTION
## Description
Make route creation use `aws_route.destination_ipv6_cidr_block` for attachments with `ipv6_support` set to `true`.

## Motivation and Context
Creating routes for TGW attachments breaks the generally working support for IPv6 based setups.
- Resolves #101 
- Resolves #112

## Breaking Changes
There should be no negative effect on backwards compatibility with the current major version.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
