### PR TITLE
feat: Added tags per VPC attachment

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -65,6 +65,9 @@ module "tgw" {
           destination_cidr_block = "10.10.10.10/32"
         }
       ]
+      tags = {
+        Name = "${local.name}-vpc2"
+      }
     },
   }
 

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
     var.tags,
     { Name = var.name },
     var.tgw_vpc_attachment_tags,
-    each.value.tags,
+    try(each.value.tags, {}),
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
     var.tags,
     { Name = var.name },
     var.tgw_vpc_attachment_tags,
+    each.value.tags,
   )
 }
 


### PR DESCRIPTION
## Description

Added an option to override tags on VPC attachment level in case you need some unique tags or override VPC attachment name

## Motivation and Context

I would like to have a unique name or some specific list of tags for every VPC attachment created by the module.

## Breaking Changes

Not expected.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
