### PR TITLE
fix: Create only one transit gateway route table

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.77.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 ################################################################################
 
 resource "aws_ec2_transit_gateway_route_table" "this" {
-  count = var.create_tgw ? 1 : 0
+  count = var.create_tgw && !var.enable_default_route_table_association && !var.enable_default_route_table_propagation ? 1 : 0
 
   transit_gateway_id = aws_ec2_transit_gateway.this[0].id
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Do not create the Transit Gateway route table if the Transit Gateway default route table is set. 

Transit Gateway default route table is set when  `enable_default_route_table_association` and `enable_default_route_table_propagation` are `true`

## Motivation and Context

When you want to create a transit gateway with this module, a TransitGateway is created by default (by terraform). 
But if we decide to use the Transit Gateway route table that will be created by AWS when the attributes  (`enable_default_route_table_association` `enable_default_route_table_propagation`) are set to `true`, then this `aws_ec2_transit_gateway_route_table` route table is no longer necessary.

related to : https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/105

The goal is not to create an unused route table. 


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
There should be no bad effect on backwards compatibility.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
