### PR TITLE
fix: Change how ram principals resource is treated by terraform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,9 +162,9 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  count = var.create_tgw && var.share_tgw ? length(var.ram_principals) : 0
+  for_each = var.create_tgw && var.share_tgw ? toset(var.ram_principals) : null
 
-  principal          = var.ram_principals[count.index]
+  principal          = each.key
   resource_share_arn = aws_ram_resource_share.this[0].arn
 }
 


### PR DESCRIPTION
## Description
Having the ram_principals as an array/list, would break terraform states on applies once the principal list is changed.
this causes a bit of a nuisance and downtime when applying changes to the tgw

## Motivation and Context
Having the ram_principals as an array/list, would break terraform states on applies once the principal list is changed.
this causes a bit of a nuisance as terraform, which orders list resources by index, now needs to destroy and then create new principals with updated index. this seems unnecessary

## Breaking Changes
Yes, this does break backwards compatibility, but imo this will fix the flake with plans for good.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s) - No Change in how the module is invoked
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects 
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
I had a local deploy with v2.9.0 release, updated the module source and made sure i migrated the terraform states appropriately, added a new aws account, terraform plan only showed additions to the plan, as expected
- [x] I have executed `pre-commit run -a` on my pull request
