### PR TITLE
feat: Fixed typo in mutlicast to multicast, also in the variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-* Added TGW mutlicast support ([#73](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/73)) ([a4d569b](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/commit/a4d569b7f03443921d9dff7ce54f8acc06aed7fa))
+* Added TGW multicast support ([#73](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/73)) ([a4d569b](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/commit/a4d569b7f03443921d9dff7ce54f8acc06aed7fa))
 
 ## [2.7.0](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/compare/v2.6.0...v2.7.0) (2022-03-26)
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ No modules.
 | <a name="input_enable_default_route_table_association"></a> [enable\_default\_route\_table\_association](#input\_enable\_default\_route\_table\_association) | Whether resource attachments are automatically associated with the default association route table | `bool` | `true` | no |
 | <a name="input_enable_default_route_table_propagation"></a> [enable\_default\_route\_table\_propagation](#input\_enable\_default\_route\_table\_propagation) | Whether resource attachments automatically propagate routes to the default propagation route table | `bool` | `true` | no |
 | <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | Should be true to enable DNS support in the TGW | `bool` | `true` | no |
-| <a name="input_enable_mutlicast_support"></a> [enable\_mutlicast\_support](#input\_enable\_mutlicast\_support) | Whether multicast support is enabled | `bool` | `false` | no |
+| <a name="input_enable_multicast_support"></a> [enable\_multicast\_support](#input\_enable\_multicast\_support) | Whether multicast support is enabled | `bool` | `false` | no |
 | <a name="input_enable_vpn_ecmp_support"></a> [enable\_vpn\_ecmp\_support](#input\_enable\_vpn\_ecmp\_support) | Whether VPN Equal Cost Multipath Protocol support is enabled | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier | `string` | `""` | no |
 | <a name="input_ram_allow_external_principals"></a> [ram\_allow\_external\_principals](#input\_ram\_allow\_external\_principals) | Indicates whether principals outside your organization can be associated with a resource share. | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,7 +30,7 @@ module "tgw" {
   enable_auto_accept_shared_attachments = true
 
   # When "true", allows service discovery through IGMP
-  enable_mutlicast_support = false
+  enable_multicast_support = false
 
   vpc_attachments = {
     vpc1 = {

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_ec2_transit_gateway" "this" {
   default_route_table_association = var.enable_default_route_table_association ? "enable" : "disable"
   default_route_table_propagation = var.enable_default_route_table_propagation ? "enable" : "disable"
   auto_accept_shared_attachments  = var.enable_auto_accept_shared_attachments ? "enable" : "disable"
-  multicast_support               = var.enable_mutlicast_support ? "enable" : "disable"
+  multicast_support               = var.enable_multicast_support ? "enable" : "disable"
   vpn_ecmp_support                = var.enable_vpn_ecmp_support ? "enable" : "disable"
   dns_support                     = var.enable_dns_support ? "enable" : "disable"
   transit_gateway_cidr_blocks     = var.transit_gateway_cidr_blocks

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "enable_vpn_ecmp_support" {
   default     = true
 }
 
-variable "enable_mutlicast_support" {
+variable "enable_multicast_support" {
   description = "Whether multicast support is enabled"
   type        = bool
   default     = false


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix multicast typo mutlicast > multicast
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Incorrect spelling
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
