### PR TITLE
Significant refactor

### DIFF
--- a/examples/multi-account/README.md
+++ b/examples/multi-account/README.md
@@ -30,10 +30,14 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_tgw"></a> [tgw](#module\_tgw) | ../../ | n/a |
-| <a name="module_tgw_peer"></a> [tgw\_peer](#module\_tgw\_peer) | ../../ | n/a |
-| <a name="module_vpc1"></a> [vpc1](#module\_vpc1) | terraform-aws-modules/vpc/aws | ~> 3.0 |
-| <a name="module_vpc2"></a> [vpc2](#module\_vpc2) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_peer_hub"></a> [peer\_hub](#module\_peer\_hub) | ../../ | n/a |
+| <a name="module_peer_hub_vpc"></a> [peer\_hub\_vpc](#module\_peer\_hub\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_peer_spoke"></a> [peer\_spoke](#module\_peer\_spoke) | ../../ | n/a |
+| <a name="module_peer_spoke_vpc"></a> [peer\_spoke\_vpc](#module\_peer\_spoke\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_primary_hub"></a> [primary\_hub](#module\_primary\_hub) | ../../ | n/a |
+| <a name="module_primary_hub_vpc"></a> [primary\_hub\_vpc](#module\_primary\_hub\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_primary_spoke"></a> [primary\_spoke](#module\_primary\_spoke) | ../../ | n/a |
+| <a name="module_primary_spoke_vpc"></a> [primary\_spoke\_vpc](#module\_primary\_spoke\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources
 
@@ -47,21 +51,42 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_ec2_transit_gateway_arn"></a> [ec2\_transit\_gateway\_arn](#output\_ec2\_transit\_gateway\_arn) | EC2 Transit Gateway Amazon Resource Name (ARN) |
-| <a name="output_ec2_transit_gateway_association_default_route_table_id"></a> [ec2\_transit\_gateway\_association\_default\_route\_table\_id](#output\_ec2\_transit\_gateway\_association\_default\_route\_table\_id) | Identifier of the default association route table |
-| <a name="output_ec2_transit_gateway_id"></a> [ec2\_transit\_gateway\_id](#output\_ec2\_transit\_gateway\_id) | EC2 Transit Gateway identifier |
-| <a name="output_ec2_transit_gateway_owner_id"></a> [ec2\_transit\_gateway\_owner\_id](#output\_ec2\_transit\_gateway\_owner\_id) | Identifier of the AWS account that owns the EC2 Transit Gateway |
-| <a name="output_ec2_transit_gateway_propagation_default_route_table_id"></a> [ec2\_transit\_gateway\_propagation\_default\_route\_table\_id](#output\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id) | Identifier of the default propagation route table |
-| <a name="output_ec2_transit_gateway_route_ids"></a> [ec2\_transit\_gateway\_route\_ids](#output\_ec2\_transit\_gateway\_route\_ids) | List of EC2 Transit Gateway Route Table identifier combined with destination |
-| <a name="output_ec2_transit_gateway_route_table_association"></a> [ec2\_transit\_gateway\_route\_table\_association](#output\_ec2\_transit\_gateway\_route\_table\_association) | Map of EC2 Transit Gateway Route Table Association attributes |
-| <a name="output_ec2_transit_gateway_route_table_association_ids"></a> [ec2\_transit\_gateway\_route\_table\_association\_ids](#output\_ec2\_transit\_gateway\_route\_table\_association\_ids) | List of EC2 Transit Gateway Route Table Association identifiers |
-| <a name="output_ec2_transit_gateway_route_table_default_association_route_table"></a> [ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table](#output\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table) | Boolean whether this is the default association route table for the EC2 Transit Gateway |
-| <a name="output_ec2_transit_gateway_route_table_default_propagation_route_table"></a> [ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table](#output\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table) | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
-| <a name="output_ec2_transit_gateway_route_table_id"></a> [ec2\_transit\_gateway\_route\_table\_id](#output\_ec2\_transit\_gateway\_route\_table\_id) | EC2 Transit Gateway Route Table identifier |
-| <a name="output_ec2_transit_gateway_route_table_propagation"></a> [ec2\_transit\_gateway\_route\_table\_propagation](#output\_ec2\_transit\_gateway\_route\_table\_propagation) | Map of EC2 Transit Gateway Route Table Propagation attributes |
-| <a name="output_ec2_transit_gateway_route_table_propagation_ids"></a> [ec2\_transit\_gateway\_route\_table\_propagation\_ids](#output\_ec2\_transit\_gateway\_route\_table\_propagation\_ids) | List of EC2 Transit Gateway Route Table Propagation identifiers |
-| <a name="output_ec2_transit_gateway_vpc_attachment"></a> [ec2\_transit\_gateway\_vpc\_attachment](#output\_ec2\_transit\_gateway\_vpc\_attachment) | Map of EC2 Transit Gateway VPC Attachment attributes |
-| <a name="output_ec2_transit_gateway_vpc_attachment_ids"></a> [ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
-| <a name="output_ram_principal_association_id"></a> [ram\_principal\_association\_id](#output\_ram\_principal\_association\_id) | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
-| <a name="output_ram_resource_share_id"></a> [ram\_resource\_share\_id](#output\_ram\_resource\_share\_id) | The Amazon Resource Name (ARN) of the resource share |
+| <a name="output_peer_hub_ec2_transit_gateway_arn"></a> [peer\_hub\_ec2\_transit\_gateway\_arn](#output\_peer\_hub\_ec2\_transit\_gateway\_arn) | EC2 Transit Gateway Amazon Resource Name (ARN) |
+| <a name="output_peer_hub_ec2_transit_gateway_association_default_route_table_id"></a> [peer\_hub\_ec2\_transit\_gateway\_association\_default\_route\_table\_id](#output\_peer\_hub\_ec2\_transit\_gateway\_association\_default\_route\_table\_id) | Identifier of the default association route table |
+| <a name="output_peer_hub_ec2_transit_gateway_id"></a> [peer\_hub\_ec2\_transit\_gateway\_id](#output\_peer\_hub\_ec2\_transit\_gateway\_id) | EC2 Transit Gateway identifier |
+| <a name="output_peer_hub_ec2_transit_gateway_owner_id"></a> [peer\_hub\_ec2\_transit\_gateway\_owner\_id](#output\_peer\_hub\_ec2\_transit\_gateway\_owner\_id) | Identifier of the AWS account that owns the EC2 Transit Gateway |
+| <a name="output_peer_hub_ec2_transit_gateway_propagation_default_route_table_id"></a> [peer\_hub\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id](#output\_peer\_hub\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id) | Identifier of the default propagation route table |
+| <a name="output_peer_hub_ec2_transit_gateway_route_ids"></a> [peer\_hub\_ec2\_transit\_gateway\_route\_ids](#output\_peer\_hub\_ec2\_transit\_gateway\_route\_ids) | List of EC2 Transit Gateway Route Table identifier combined with destination |
+| <a name="output_peer_hub_ec2_transit_gateway_route_table_association"></a> [peer\_hub\_ec2\_transit\_gateway\_route\_table\_association](#output\_peer\_hub\_ec2\_transit\_gateway\_route\_table\_association) | Map of EC2 Transit Gateway Route Table Association attributes |
+| <a name="output_peer_hub_ec2_transit_gateway_route_table_association_ids"></a> [peer\_hub\_ec2\_transit\_gateway\_route\_table\_association\_ids](#output\_peer\_hub\_ec2\_transit\_gateway\_route\_table\_association\_ids) | List of EC2 Transit Gateway Route Table Association identifiers |
+| <a name="output_peer_hub_ec2_transit_gateway_route_table_default_association_route_table"></a> [peer\_hub\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table](#output\_peer\_hub\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table) | Boolean whether this is the default association route table for the EC2 Transit Gateway |
+| <a name="output_peer_hub_ec2_transit_gateway_route_table_default_propagation_route_table"></a> [peer\_hub\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table](#output\_peer\_hub\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table) | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
+| <a name="output_peer_hub_ec2_transit_gateway_route_table_id"></a> [peer\_hub\_ec2\_transit\_gateway\_route\_table\_id](#output\_peer\_hub\_ec2\_transit\_gateway\_route\_table\_id) | EC2 Transit Gateway Route Table identifier |
+| <a name="output_peer_hub_ec2_transit_gateway_route_table_propagation"></a> [peer\_hub\_ec2\_transit\_gateway\_route\_table\_propagation](#output\_peer\_hub\_ec2\_transit\_gateway\_route\_table\_propagation) | Map of EC2 Transit Gateway Route Table Propagation attributes |
+| <a name="output_peer_hub_ec2_transit_gateway_route_table_propagation_ids"></a> [peer\_hub\_ec2\_transit\_gateway\_route\_table\_propagation\_ids](#output\_peer\_hub\_ec2\_transit\_gateway\_route\_table\_propagation\_ids) | List of EC2 Transit Gateway Route Table Propagation identifiers |
+| <a name="output_peer_hub_ec2_transit_gateway_vpc_attachment"></a> [peer\_hub\_ec2\_transit\_gateway\_vpc\_attachment](#output\_peer\_hub\_ec2\_transit\_gateway\_vpc\_attachment) | Map of EC2 Transit Gateway VPC Attachment attributes |
+| <a name="output_peer_hub_ec2_transit_gateway_vpc_attachment_ids"></a> [peer\_hub\_ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_peer\_hub\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
+| <a name="output_peer_hub_ram_principal_association_id"></a> [peer\_hub\_ram\_principal\_association\_id](#output\_peer\_hub\_ram\_principal\_association\_id) | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
+| <a name="output_peer_hub_ram_resource_share_id"></a> [peer\_hub\_ram\_resource\_share\_id](#output\_peer\_hub\_ram\_resource\_share\_id) | The Amazon Resource Name (ARN) of the resource share |
+| <a name="output_peer_spoke_ec2_transit_gateway_vpc_attachment"></a> [peer\_spoke\_ec2\_transit\_gateway\_vpc\_attachment](#output\_peer\_spoke\_ec2\_transit\_gateway\_vpc\_attachment) | Map of EC2 Transit Gateway VPC Attachment attributes |
+| <a name="output_peer_spoke_ec2_transit_gateway_vpc_attachment_ids"></a> [peer\_spoke\_ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_peer\_spoke\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
+| <a name="output_primary_hub_ec2_transit_gateway_arn"></a> [primary\_hub\_ec2\_transit\_gateway\_arn](#output\_primary\_hub\_ec2\_transit\_gateway\_arn) | EC2 Transit Gateway Amazon Resource Name (ARN) |
+| <a name="output_primary_hub_ec2_transit_gateway_association_default_route_table_id"></a> [primary\_hub\_ec2\_transit\_gateway\_association\_default\_route\_table\_id](#output\_primary\_hub\_ec2\_transit\_gateway\_association\_default\_route\_table\_id) | Identifier of the default association route table |
+| <a name="output_primary_hub_ec2_transit_gateway_id"></a> [primary\_hub\_ec2\_transit\_gateway\_id](#output\_primary\_hub\_ec2\_transit\_gateway\_id) | EC2 Transit Gateway identifier |
+| <a name="output_primary_hub_ec2_transit_gateway_owner_id"></a> [primary\_hub\_ec2\_transit\_gateway\_owner\_id](#output\_primary\_hub\_ec2\_transit\_gateway\_owner\_id) | Identifier of the AWS account that owns the EC2 Transit Gateway |
+| <a name="output_primary_hub_ec2_transit_gateway_propagation_default_route_table_id"></a> [primary\_hub\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id](#output\_primary\_hub\_ec2\_transit\_gateway\_propagation\_default\_route\_table\_id) | Identifier of the default propagation route table |
+| <a name="output_primary_hub_ec2_transit_gateway_route_ids"></a> [primary\_hub\_ec2\_transit\_gateway\_route\_ids](#output\_primary\_hub\_ec2\_transit\_gateway\_route\_ids) | List of EC2 Transit Gateway Route Table identifier combined with destination |
+| <a name="output_primary_hub_ec2_transit_gateway_route_table_association"></a> [primary\_hub\_ec2\_transit\_gateway\_route\_table\_association](#output\_primary\_hub\_ec2\_transit\_gateway\_route\_table\_association) | Map of EC2 Transit Gateway Route Table Association attributes |
+| <a name="output_primary_hub_ec2_transit_gateway_route_table_association_ids"></a> [primary\_hub\_ec2\_transit\_gateway\_route\_table\_association\_ids](#output\_primary\_hub\_ec2\_transit\_gateway\_route\_table\_association\_ids) | List of EC2 Transit Gateway Route Table Association identifiers |
+| <a name="output_primary_hub_ec2_transit_gateway_route_table_default_association_route_table"></a> [primary\_hub\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table](#output\_primary\_hub\_ec2\_transit\_gateway\_route\_table\_default\_association\_route\_table) | Boolean whether this is the default association route table for the EC2 Transit Gateway |
+| <a name="output_primary_hub_ec2_transit_gateway_route_table_default_propagation_route_table"></a> [primary\_hub\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table](#output\_primary\_hub\_ec2\_transit\_gateway\_route\_table\_default\_propagation\_route\_table) | Boolean whether this is the default propagation route table for the EC2 Transit Gateway |
+| <a name="output_primary_hub_ec2_transit_gateway_route_table_id"></a> [primary\_hub\_ec2\_transit\_gateway\_route\_table\_id](#output\_primary\_hub\_ec2\_transit\_gateway\_route\_table\_id) | EC2 Transit Gateway Route Table identifier |
+| <a name="output_primary_hub_ec2_transit_gateway_route_table_propagation"></a> [primary\_hub\_ec2\_transit\_gateway\_route\_table\_propagation](#output\_primary\_hub\_ec2\_transit\_gateway\_route\_table\_propagation) | Map of EC2 Transit Gateway Route Table Propagation attributes |
+| <a name="output_primary_hub_ec2_transit_gateway_route_table_propagation_ids"></a> [primary\_hub\_ec2\_transit\_gateway\_route\_table\_propagation\_ids](#output\_primary\_hub\_ec2\_transit\_gateway\_route\_table\_propagation\_ids) | List of EC2 Transit Gateway Route Table Propagation identifiers |
+| <a name="output_primary_hub_ec2_transit_gateway_vpc_attachment"></a> [primary\_hub\_ec2\_transit\_gateway\_vpc\_attachment](#output\_primary\_hub\_ec2\_transit\_gateway\_vpc\_attachment) | Map of EC2 Transit Gateway VPC Attachment attributes |
+| <a name="output_primary_hub_ec2_transit_gateway_vpc_attachment_ids"></a> [primary\_hub\_ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_primary\_hub\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
+| <a name="output_primary_hub_ram_principal_association_id"></a> [primary\_hub\_ram\_principal\_association\_id](#output\_primary\_hub\_ram\_principal\_association\_id) | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
+| <a name="output_primary_hub_ram_resource_share_id"></a> [primary\_hub\_ram\_resource\_share\_id](#output\_primary\_hub\_ram\_resource\_share\_id) | The Amazon Resource Name (ARN) of the resource share |
+| <a name="output_primary_spoke_ec2_transit_gateway_vpc_attachment"></a> [primary\_spoke\_ec2\_transit\_gateway\_vpc\_attachment](#output\_primary\_spoke\_ec2\_transit\_gateway\_vpc\_attachment) | Map of EC2 Transit Gateway VPC Attachment attributes |
+| <a name="output_primary_spoke_ec2_transit_gateway_vpc_attachment_ids"></a> [primary\_spoke\_ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_primary\_spoke\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-account/main.tf
+++ b/examples/multi-account/main.tf
@@ -1,21 +1,55 @@
 provider "aws" {
-  region = local.region
+  region = local.primary_region
+}
+
+# This provider is required for TGW and peering attachment installation in another AWS Account
+provider "aws" {
+  region = local.secondary_region
+  alias  = "peer_hub"
 }
 
 # This provider is required for attachment only installation in another AWS Account
 provider "aws" {
-  region = local.region
-  alias  = "peer"
+  region = local.primary_region
+  alias  = "primary_spoke"
+}
+
+# This provider is required for attachment only installation in another AWS Account
+provider "aws" {
+  region = local.secondary_region
+  alias  = "peer_spoke"
 }
 
 locals {
-  name   = "ex-tgw-${replace(basename(path.cwd), "_", "-")}"
-  region = "eu-west-1"
+  name = "ex-tgw-${replace(basename(path.cwd), "_", "-")}"
+
+  primary_region   = "eu-west-1"
+  secondary_region = "eu-west-2"
+
+  primary_hub_account_id   = "012345678901"
+  peer_hub_account_id      = "123456789012"
+  primary_spoke_account_id = "234567890123"
+  peer_spoke_account_id    = "345678901234"
+
+  primary_hub_flow_logs_cloudwatch_dest_arn     = "arn:aws:logs:${local.primary_region}:${local.primary_hub_account_id}:log-group:/aws/tgw/"
+  primary_hub_flow_logs_cloudwatch_iam_role_arn = "arn:aws:iam::${local.primary_hub_account_id}:role/tgw-flow-logs-to-cloudwatch"
+  primary_hub_flow_logs_s3_dest_arn             = "arn:aws:s3:::tgw-flow-logs-${local.primary_hub_account_id}-${local.primary_region}"
+
+  primary_spoke_flow_logs_cloudwatch_dest_arn     = "arn:aws:logs:${local.primary_region}:${local.primary_spoke_account_id}:log-group:/aws/tgw/"
+  primary_spoke_flow_logs_cloudwatch_iam_role_arn = "arn:aws:iam::${local.primary_spoke_account_id}:role/tgw-flow-logs-to-cloudwatch"
+  primary_spoke_flow_logs_s3_dest_arn             = "arn:aws:s3:::tgw-flow-logs-${local.primary_spoke_account_id}-${local.primary_region}"
+
+  peer_hub_flow_logs_cloudwatch_dest_arn     = "arn:aws:logs:${local.secondary_region}:${local.peer_hub_account_id}:log-group:/aws/tgw/"
+  peer_hub_flow_logs_cloudwatch_iam_role_arn = "arn:aws:iam::${local.peer_hub_account_id}:role/tgw-flow-logs-to-cloudwatch"
+  peer_hub_flow_logs_s3_dest_arn             = "arn:aws:s3:::tgw-flow-logs-${local.peer_hub_account_id}-${local.secondary_region}"
+
+  peer_spoke_flow_logs_cloudwatch_dest_arn     = "arn:aws:logs:${local.secondary_region}:${local.peer_spoke_account_id}:log-group:/aws/tgw/"
+  peer_spoke_flow_logs_cloudwatch_iam_role_arn = "arn:aws:iam::${local.peer_spoke_account_id}:role/tgw-flow-logs-to-cloudwatch"
+  peer_spoke_flow_logs_s3_dest_arn             = "arn:aws:s3:::tgw-flow-logs-${local.peer_spoke_account_id}-${local.secondary_region}"
 
   tags = {
     Example    = local.name
-    GithubRepo = "terraform-aws-eks"
-    GithubOrg  = "terraform-aws-transit-gateway"
+    GithubRepo = "terraform-aws-transit-gateway"
   }
 }
 
@@ -23,101 +57,598 @@ locals {
 # Transit Gateway Module
 ################################################################################
 
-module "tgw" {
+module "primary_hub" {
   source = "../../"
 
   name            = local.name
-  description     = "My TGW shared with several other AWS accounts"
+  description     = "Primary Hub TGW shared with several other AWS accounts in ${local.primary_region}"
   amazon_side_asn = 64532
 
+  create_tgw = true
+  # Creates RAM resources for hub (create_tgw = true) accounts
+  share_tgw = true
+
   # When "true" there is no need for RAM resources if using multiple AWS accounts
-  enable_auto_accept_shared_attachments = true
+  enable_auto_accept_shared_attachments = false
 
-  vpc_attachments = {
-    vpc1 = {
-      vpc_id       = module.vpc1.vpc_id
-      subnet_ids   = module.vpc1.private_subnets
-      dns_support  = true
-      ipv6_support = true
+  enable_default_route_table_association = false
+  enable_default_route_table_propagation = false
 
+  flow_logs = [
+    {
+      cloudwatch_dest_arn     = local.primary_hub_flow_logs_cloudwatch_dest_arn
+      cloudwatch_iam_role_arn = local.primary_hub_flow_logs_cloudwatch_iam_role_arn
+      # Enable destinations after all TGWs/attachments are created/accepted
+      dest_enabled = true
+      dest_type    = "cloud-watch-logs"
+      key          = "tgw"
+      s3_dest_arn  = null
+    },
+    {
+      cloudwatch_dest_arn     = null
+      cloudwatch_iam_role_arn = null
+      # Enable destinations after all TGWs/attachments are created/accepted
+      dest_enabled = true
+      dest_type    = "s3"
+      key          = "tgw"
+      s3_dest_arn  = local.primary_hub_flow_logs_s3_dest_arn
+    },
+    {
+      attachment_type         = "vpc"
+      cloudwatch_dest_arn     = local.primary_hub_flow_logs_cloudwatch_dest_arn
+      cloudwatch_iam_role_arn = local.primary_hub_flow_logs_cloudwatch_iam_role_arn
+      create_tgw_peering      = false
+      create_vpc_attachment   = true
+      # Enable destinations after all TGWs/attachments are created/accepted
+      dest_enabled = true
+      dest_type    = "cloud-watch-logs"
+      key          = "primary_hub_local"
+      s3_dest_arn  = null
+    },
+    {
+      attachment_type         = "vpc"
+      cloudwatch_dest_arn     = null
+      cloudwatch_iam_role_arn = null
+      create_tgw_peering      = false
+      create_vpc_attachment   = true
+      # Enable destinations after all TGWs/attachments are created/accepted
+      dest_enabled = true
+      dest_type    = "s3"
+      key          = "primary_hub_local"
+      s3_dest_arn  = local.primary_hub_flow_logs_s3_dest_arn
+    },
+    {
+      attachment_type         = "peering"
+      cloudwatch_dest_arn     = local.primary_hub_flow_logs_cloudwatch_dest_arn
+      cloudwatch_iam_role_arn = local.primary_hub_flow_logs_cloudwatch_iam_role_arn
+      create_tgw_peering      = true
+      create_vpc_attachment   = false
+      # Enable destinations after all TGWs/attachments are created/accepted
+      dest_enabled = true
+      dest_type    = "cloud-watch-logs"
+      key          = "peer_hub"
+      s3_dest_arn  = null
+    },
+    {
+      attachment_type         = "peering"
+      cloudwatch_dest_arn     = null
+      cloudwatch_iam_role_arn = null
+      create_tgw_peering      = true
+      create_vpc_attachment   = false
+      # Enable destinations after all TGWs/attachments are created/accepted
+      dest_enabled = true
+      dest_type    = "s3"
+      key          = "peer_hub"
+      s3_dest_arn  = local.primary_hub_flow_logs_s3_dest_arn
+    },
+  ]
+
+  tgw_route_tables = [
+    "prod",
+    "staging",
+  ]
+
+  attachments = {
+    peer_hub = {
+      attachment_type     = "peering"
+      create_tgw_peering  = true
+      peer_account_id     = local.peer_hub_account_id
+      peer_region         = local.secondary_region
+      peer_tgw_id         = module.peer_hub.ec2_transit_gateway_id
+      vpc_route_table_ids = module.primary_hub_vpc.private_route_table_ids
+      # Keep create_vpc_routes = false until the TGW is created and all attachments are created/accepted
+      create_vpc_routes = false
+      vpc_route_table_destination_cidrs = [
+        module.peer_hub_vpc.vpc_cidr_block,
+      ]
       transit_gateway_default_route_table_association = false
       transit_gateway_default_route_table_propagation = false
-
-      tgw_routes = [
-        {
-          destination_cidr_block = "30.0.0.0/16"
+      # Keep create_tgw_routes = false until the VPC/peering attachments exist/are accepted
+      create_tgw_routes = true
+      tgw_route_table_propagations = {
+        prod = {
+          enable = true
         },
-        {
-          blackhole              = true
-          destination_cidr_block = "0.0.0.0/0"
+        staging = {
+          enable = true
         }
-      ]
-    },
-    vpc2 = {
-      vpc_id     = module.vpc2.vpc_id
-      subnet_ids = module.vpc2.private_subnets
-
-      tgw_routes = [
-        {
-          destination_cidr_block = "50.0.0.0/16"
-        },
-        {
-          blackhole              = true
-          destination_cidr_block = "10.10.10.10/32"
+      }
+      tgw_routes = {
+        peer_hub = {
+          destination_cidr_blocks = module.peer_hub_vpc.vpc_cidr_block
+          route_table             = "prod"
         }
+        blackhole = {
+          blackhole               = true
+          destination_cidr_blocks = "0.0.0.0/0"
+          route_table             = "prod"
+        }
+      }
+    }
+    primary_hub_local = {
+      attachment_type       = "vpc"
+      create_vpc_attachment = true
+      # Keep enable_vpc_attachment = false until the corresponding VPC attachment is created/accepted
+      enable_vpc_attachment                           = false
+      vpc_id                                          = module.primary_hub_vpc.vpc_id
+      subnet_ids                                      = module.primary_hub_vpc.private_subnets
+      transit_gateway_default_route_table_association = false
+      transit_gateway_default_route_table_propagation = false
+      ipv6_support                                    = true
+      # Keep create_tgw_routes = false until the VPC/peering attachments exist/are accepted
+      create_tgw_routes = true
+      tgw_route_table_propagations = {
+        prod = {
+          enable = true
+        }
+      }
+      tgw_routes = {
+        primary_hub_local = {
+          destination_cidr_blocks = module.primary_hub_vpc.vpc_cidr_block
+          route_table             = "prod"
+        }
+        blackhole = {
+          blackhole               = true
+          destination_cidr_blocks = "0.0.0.0/0"
+          route_table             = "prod"
+        }
+      }
+    }
+    primary_spoke = {
+      attachment_type = "vpc"
+      # Keep accept_vpc_attachment = false until the corresponding VPC attachment is created
+      accept_vpc_attachment = false
+      # Keep enable_vpc_attachment = false until the corresponding VPC attachment is created
+      # Set to true when accepting the attachment
+      enable_vpc_attachment = false
+      vpc_id                = module.primary_spoke_vpc.vpc_id
+      vpc_route_table_ids   = module.primary_hub_vpc.private_route_table_ids
+      # Keep create_vpc_routes = false until the TGW is created and all attachments are created/accepted
+      create_vpc_routes = false
+      vpc_route_table_destination_cidrs = [
+        module.primary_spoke_vpc.vpc_cidr_block,
       ]
-    },
+      transit_gateway_default_route_table_association = false
+      transit_gateway_default_route_table_propagation = false
+      # Keep create_tgw_routes = false until the VPC/peering attachments exist/are accepted
+      create_tgw_routes = true
+      tgw_route_table_propagations = {
+        staging = {
+          enable = true
+        }
+      }
+      tgw_routes = {
+        primary_spoke = {
+          destination_cidr_blocks = module.primary_spoke_vpc.private_subnets_cidr_blocks
+          route_table             = "staging"
+        }
+        blackhole = {
+          blackhole               = true
+          destination_cidr_blocks = ["0.0.0.0/0"]
+          route_table             = "staging"
+        }
+      }
+    }
+    peer_spoke = {
+      attachment_type = "peering"
+      # For peering attachments that aren't accepted by this module, keep enable_peering_attachment = false until the peering attachment is accepted
+      enable_peering_attachment = true
+      peer_account_id           = local.peer_hub_account_id
+      vpc_route_table_ids       = module.primary_hub_vpc.private_route_table_ids
+      # Keep create_vpc_routes = false until the TGW is created and all attachments are created/accepted
+      create_vpc_routes = false
+      vpc_route_table_destination_cidrs = [
+        module.peer_spoke_vpc.vpc_cidr_block,
+      ]
+      transit_gateway_default_route_table_association = false
+      transit_gateway_default_route_table_propagation = false
+      # Keep create_tgw_routes = false until the VPC/peering attachments exist/are accepted
+      create_tgw_routes = true
+      tgw_routes = {
+        peer_spoke = {
+          destination_cidr_blocks = module.peer_spoke_vpc.private_subnets_cidr_blocks
+          route_table             = "staging"
+        }
+        blackhole = {
+          blackhole               = true
+          destination_cidr_blocks = ["0.0.0.0/0"]
+          route_table             = "staging"
+        }
+      }
+    }
   }
 
-  ram_allow_external_principals = true
-  ram_principals                = [307990089504]
+  ram_allow_external_principals = false
+  ram_principals = [
+    local.peer_hub_account_id,
+    local.primary_spoke_account_id,
+  ]
 
   tags = local.tags
 }
 
-module "tgw_peer" {
-  # This is optional and connects to another account. Meaning you need to be authenticated with 2 separate AWS Accounts
+module "peer_hub" {
+  # This is optional and connects to another account. Meaning you need to be authenticated with multiple separate AWS Accounts
   source = "../../"
 
   providers = {
-    aws = aws.peer
+    aws = aws.peer_hub
   }
 
-  name            = "${local.name}-peer"
-  description     = "My TGW shared with several other AWS accounts"
+  name            = "${local.name}-peer-hub"
+  description     = "Peer Hub TGW shared with several other AWS accounts in ${local.secondary_region}"
   amazon_side_asn = 64532
 
-  create_tgw             = false
-  share_tgw              = true
-  ram_resource_share_arn = module.tgw.ram_resource_share_id
+  create_tgw = true
+  # Creates RAM resources for hub (create_tgw = true) accounts
+  share_tgw = true
+
   # When "true" there is no need for RAM resources if using multiple AWS accounts
-  enable_auto_accept_shared_attachments = true
+  enable_auto_accept_shared_attachments = false
 
-  vpc_attachments = {
-    vpc1 = {
-      tgw_id       = module.tgw.ec2_transit_gateway_id
-      vpc_id       = module.vpc1.vpc_id
-      subnet_ids   = module.vpc1.private_subnets
-      dns_support  = true
-      ipv6_support = true
+  enable_default_route_table_association = false
+  enable_default_route_table_propagation = false
 
+  flow_logs = [
+    {
+      cloudwatch_dest_arn     = local.peer_hub_flow_logs_cloudwatch_dest_arn
+      cloudwatch_iam_role_arn = local.peer_hub_flow_logs_cloudwatch_iam_role_arn
+      dest_enabled            = true
+      dest_type               = "cloud-watch-logs"
+      key                     = "tgw"
+      s3_dest_arn             = null
+    },
+    {
+      cloudwatch_dest_arn     = null
+      cloudwatch_iam_role_arn = null
+      dest_enabled            = true
+      dest_type               = "s3"
+      key                     = "tgw"
+      s3_dest_arn             = local.peer_hub_flow_logs_s3_dest_arn
+    },
+    {
+      attachment_type         = "vpc"
+      cloudwatch_dest_arn     = local.peer_hub_flow_logs_cloudwatch_dest_arn
+      cloudwatch_iam_role_arn = local.peer_hub_flow_logs_cloudwatch_iam_role_arn
+      create_tgw_peering      = false
+      create_vpc_attachment   = true
+      dest_enabled            = true
+      dest_type               = "cloud-watch-logs"
+      key                     = "peer_hub_local"
+      s3_dest_arn             = null
+    },
+    {
+      attachment_type         = "vpc"
+      cloudwatch_dest_arn     = null
+      cloudwatch_iam_role_arn = null
+      create_tgw_peering      = false
+      create_vpc_attachment   = true
+      dest_enabled            = true
+      dest_type               = "s3"
+      key                     = "peer_hub_local"
+      s3_dest_arn             = local.peer_hub_flow_logs_s3_dest_arn
+    },
+  ]
+
+  tgw_route_tables = [
+    "prod",
+    "staging",
+  ]
+
+  attachments = {
+    primary_hub = {
+      attachment_type = "peering"
+      # Keep accept_tgw_peering = false until the peering attachment is created in the hub account
+      accept_tgw_peering = true
+      # For peering attachments to be accepted, keep enable_peering_attachment = false until the peering attachment is created in the hub account
+      # Set to true when accepting the attachment
+      enable_peering_attachment = true
+      peer_account_id           = local.primary_hub_account_id
+      vpc_route_table_ids       = module.peer_hub_vpc.private_route_table_ids
+      # Keep create_vpc_routes = false until the TGW is created and all attachments are created/accepted
+      create_vpc_routes = false
+      vpc_route_table_destination_cidrs = [
+        module.primary_hub_vpc.vpc_cidr_block,
+      ]
       transit_gateway_default_route_table_association = false
       transit_gateway_default_route_table_propagation = false
-
-      tgw_routes = [
-        {
-          destination_cidr_block = "30.0.0.0/16"
-        },
-        {
-          blackhole              = true
-          destination_cidr_block = "0.0.0.0/0"
+      # Keep create_tgw_routes = false until the VPC/peering attachments exist/are accepted
+      create_tgw_routes = true
+      tgw_routes = {
+        primary_hub = {
+          destination_cidr_blocks = module.primary_hub_vpc.private_subnets_cidr_blocks
+          route_table             = "prod"
         }
+        blackhole = {
+          blackhole               = true
+          destination_cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+    peer_hub_local = {
+      attachment_type       = "vpc"
+      create_vpc_attachment = true
+      # Keep enable_vpc_attachment = false until the corresponding VPC attachment is created/accepted
+      enable_vpc_attachment                           = false
+      vpc_id                                          = module.peer_hub_vpc.vpc_id
+      subnet_ids                                      = module.peer_hub_vpc.private_subnets
+      transit_gateway_default_route_table_association = false
+      transit_gateway_default_route_table_propagation = false
+      ipv6_support                                    = true
+      # Keep create_tgw_routes = false until the VPC/peering attachments exist/are accepted
+      create_tgw_routes = true
+      tgw_route_table_propagations = {
+        prod = {
+          enable = true
+        }
+      }
+      tgw_routes = {
+        peer_hub_local = {
+          destination_cidr_blocks = module.peer_hub_vpc.private_subnets_cidr_blocks
+          route_table             = "prod"
+        }
+        blackhole = {
+          blackhole               = true
+          destination_cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+    peer_spoke = {
+      attachment_type = "vpc"
+      # Keep accept_vpc_attachment = false until the corresponding VPC attachment is created
+      accept_vpc_attachment = false
+      # Keep enable_vpc_attachment = false until the corresponding VPC attachment is created/accepted
+      enable_vpc_attachment = false
+      vpc_id                = module.peer_spoke_vpc.vpc_id
+      vpc_route_table_ids   = module.peer_hub_vpc.private_route_table_ids
+      # Keep create_vpc_routes = false until the TGW is created and all attachments are created/accepted
+      create_vpc_routes = false
+      vpc_route_table_destination_cidrs = [
+        module.peer_spoke_vpc.vpc_cidr_block,
       ]
-    },
+      transit_gateway_default_route_table_association = false
+      transit_gateway_default_route_table_propagation = false
+      # Keep create_tgw_routes = false until the VPC/peering attachments exist/are accepted
+      create_tgw_routes = true
+      tgw_route_table_propagations = {
+        staging = {
+          enable = true
+        }
+      }
+      tgw_routes = {
+        peer_spoke_account = {
+          destination_cidr_blocks = module.peer_spoke_vpc.private_subnets_cidr_blocks
+          route_table             = "staging"
+        }
+        blackhole = {
+          blackhole               = true
+          destination_cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
+    primary_spoke = {
+      attachment_type = "peering"
+      # For peering attachments that aren't accepted by this module, keep enable_peering_attachment = false until the peering attachment is accepted
+      enable_peering_attachment = true
+      peer_account_id           = local.primary_hub_account_id
+      vpc_route_table_ids       = module.peer_hub_vpc.private_route_table_ids
+      # Keep create_vpc_routes = false until the TGW is created and all attachments are created/accepted
+      create_vpc_routes = false
+      vpc_route_table_destination_cidrs = [
+        module.primary_spoke_vpc.vpc_cidr_block,
+      ]
+      transit_gateway_default_route_table_association = false
+      transit_gateway_default_route_table_propagation = false
+      # Keep create_tgw_routes = false until the VPC/peering attachments exist/are accepted
+      create_tgw_routes = true
+      tgw_routes = {
+        primary_spoke = {
+          destination_cidr_blocks = module.primary_spoke_vpc.private_subnets_cidr_blocks
+          route_table             = "staging"
+        }
+        blackhole = {
+          blackhole               = true
+          destination_cidr_blocks = ["0.0.0.0/0"]
+        }
+      }
+    }
   }
 
-  ram_allow_external_principals = true
-  ram_principals                = [307990089504]
+  ram_allow_external_principals = false
+  ram_principals = [
+    local.primary_hub_account_id,
+    local.peer_spoke_account_id,
+  ]
+
+  tags = local.tags
+}
+
+module "primary_spoke" {
+  # This is optional and connects to another account. Meaning you need to be authenticated with multiple separate AWS Accounts
+  source = "../../"
+
+  providers = {
+    aws = aws.primary_spoke
+  }
+
+  create_tgw = false
+  # Creates RAM Resource Share Accepter for spoke (create_tgw = false) accounts
+  share_tgw = true
+
+  ram_resource_share_arn = module.primary_hub.ram_resource_share_id
+  description            = "Primary Spoke sharing the TGW from the Primary Hub in ${local.primary_region}"
+
+  flow_logs = [
+    {
+      attachment_type         = "vpc"
+      cloudwatch_dest_arn     = local.primary_spoke_flow_logs_cloudwatch_dest_arn
+      cloudwatch_iam_role_arn = local.primary_spoke_flow_logs_cloudwatch_iam_role_arn
+      create_tgw_peering      = false
+      create_vpc_attachment   = true
+      dest_enabled            = true
+      dest_type               = "cloud-watch-logs"
+      key                     = "primary_spoke_local"
+      s3_dest_arn             = null
+    },
+    {
+      attachment_type         = "vpc"
+      cloudwatch_dest_arn     = null
+      cloudwatch_iam_role_arn = null
+      create_tgw_peering      = false
+      create_vpc_attachment   = true
+      dest_enabled            = true
+      dest_type               = "s3"
+      key                     = "primary_spoke_local"
+      s3_dest_arn             = local.primary_spoke_flow_logs_s3_dest_arn
+    },
+  ]
+
+  attachments = {
+    primary_spoke_local = {
+      attachment_type       = "vpc"
+      create_vpc_attachment = true
+      # Keep enable_vpc_attachment = false until the corresponding VPC attachment is created/accepted
+      enable_vpc_attachment = false
+      tgw_id                = module.primary_hub.ec2_transit_gateway_id
+      vpc_id                = module.primary_spoke_vpc.vpc_id
+      subnet_ids            = module.primary_spoke_vpc.private_subnets
+      ipv6_support          = true
+    }
+    primary_hub = {
+      attachment_type = "vpc"
+      # Keep enable_vpc_attachment = false until the corresponding VPC attachment is created/accepted
+      enable_vpc_attachment = false
+      tgw_id                = module.primary_hub.ec2_transit_gateway_id
+      vpc_route_table_ids   = module.primary_spoke_vpc.private_route_table_ids
+      vpc_route_table_destination_cidrs = [
+        module.primary_hub_vpc.vpc_cidr_block,
+      ]
+    }
+    peer_hub = {
+      attachment_type     = "peering"
+      tgw_id              = module.primary_hub.ec2_transit_gateway_id
+      vpc_route_table_ids = module.primary_spoke_vpc.private_route_table_ids
+      vpc_route_table_destination_cidrs = [
+        module.peer_hub_vpc.vpc_cidr_block,
+      ]
+    }
+    peer_spoke = {
+      attachment_type     = "peering"
+      tgw_id              = module.primary_hub.ec2_transit_gateway_id
+      vpc_route_table_ids = module.primary_spoke_vpc.private_route_table_ids
+      vpc_route_table_destination_cidrs = [
+        module.peer_spoke_vpc.vpc_cidr_block,
+      ]
+    }
+  }
+
+  tags = local.tags
+}
+
+module "peer_spoke" {
+  # This is optional and connects to another account. Meaning you need to be authenticated with multiple separate AWS Accounts
+  source = "../../"
+
+  providers = {
+    aws = aws.peer_spoke
+  }
+
+  create_tgw = false
+  # Creates RAM Resource Share Accepter for spoke (create_tgw = false) accounts
+  share_tgw = true
+
+  ram_resource_share_arn = module.peer_hub.ram_resource_share_id
+  description            = "Peer Spoke sharing the TGW from the Peer Hub in ${local.secondary_region}"
+
+  flow_logs = [
+    {
+      attachment_type         = "vpc"
+      cloudwatch_dest_arn     = local.peer_spoke_flow_logs_cloudwatch_dest_arn
+      cloudwatch_iam_role_arn = local.peer_spoke_flow_logs_cloudwatch_iam_role_arn
+      create_tgw_peering      = false
+      create_vpc_attachment   = true
+      dest_enabled            = true
+      dest_type               = "cloud-watch-logs"
+      key                     = "peer_spoke_local"
+      s3_dest_arn             = null
+    },
+    {
+      attachment_type         = "vpc"
+      cloudwatch_dest_arn     = null
+      cloudwatch_iam_role_arn = null
+      create_tgw_peering      = false
+      create_vpc_attachment   = true
+      dest_enabled            = true
+      dest_type               = "s3"
+      key                     = "peer_spoke_local"
+      s3_dest_arn             = local.peer_spoke_flow_logs_s3_dest_arn
+    },
+  ]
+
+  attachments = {
+    peer_spoke_local = {
+      attachment_type       = "vpc"
+      create_vpc_attachment = true
+      # Keep enable_vpc_attachment = false until the corresponding VPC attachment is created/accepted
+      enable_vpc_attachment = false
+      tgw_id                = module.peer_hub.ec2_transit_gateway_id
+      vpc_id                = module.peer_spoke_vpc.vpc_id
+      subnet_ids            = module.peer_spoke_vpc.private_subnets
+      ipv6_support          = true
+    }
+    peer_hub = {
+      attachment_type = "vpc"
+      # Keep enable_vpc_attachment = false until the corresponding VPC attachment is created/accepted
+      enable_vpc_attachment = false
+      tgw_id                = module.peer_hub.ec2_transit_gateway_id
+      vpc_route_table_ids   = module.peer_spoke_vpc.private_route_table_ids
+      # Keep create_vpc_routes = false until the TGW is created and all attachments are created/accepted
+      create_vpc_routes = false
+      vpc_route_table_destination_cidrs = [
+        module.peer_hub_vpc.vpc_cidr_block,
+      ]
+    }
+    primary_hub = {
+      attachment_type     = "peering"
+      tgw_id              = module.peer_hub.ec2_transit_gateway_id
+      vpc_route_table_ids = module.peer_spoke_vpc.private_route_table_ids
+      # Keep create_vpc_routes = false until the TGW is created and all attachments are created/accepted
+      create_vpc_routes = false
+      vpc_route_table_destination_cidrs = [
+        module.primary_hub_vpc.vpc_cidr_block,
+      ]
+    }
+    primary_spoke = {
+      attachment_type     = "peering"
+      tgw_id              = module.peer_hub.ec2_transit_gateway_id
+      vpc_route_table_ids = module.peer_spoke_vpc.private_route_table_ids
+      # Keep create_vpc_routes = false until the TGW is created and all attachments are created/accepted
+      create_vpc_routes = false
+      vpc_route_table_destination_cidrs = [
+        module.primary_spoke_vpc.vpc_cidr_block,
+      ]
+    }
+  }
 
   tags = local.tags
 }
@@ -126,14 +657,14 @@ module "tgw_peer" {
 # Supporting resources
 ################################################################################
 
-module "vpc1" {
+module "primary_hub_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
 
-  name = "${local.name}-vpc1"
+  name = "${local.name}-primary-hub-vpc"
   cidr = "10.10.0.0/16"
 
-  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  azs             = ["${local.primary_region}a", "${local.primary_region}b", "${local.primary_region}c"]
   private_subnets = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
 
   enable_ipv6                                    = true
@@ -144,21 +675,65 @@ module "vpc1" {
 }
 
 
-module "vpc2" {
+module "peer_hub_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
 
   providers = {
-    aws = aws.peer
+    aws = aws.peer_hub
   }
 
-  name = "${local.name}-vpc2"
+  name = "${local.name}-peer-hub-vpc"
   cidr = "10.20.0.0/16"
 
-  azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  azs             = ["${local.secondary_region}a", "${local.secondary_region}b", "${local.secondary_region}c"]
   private_subnets = ["10.20.1.0/24", "10.20.2.0/24", "10.20.3.0/24"]
 
-  enable_ipv6 = false
+  enable_ipv6                                    = true
+  private_subnet_assign_ipv6_address_on_creation = true
+  private_subnet_ipv6_prefixes                   = [3, 4, 5]
+
+  tags = local.tags
+}
+
+module "primary_spoke_vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  providers = {
+    aws = aws.primary_spoke
+  }
+
+  name = "${local.name}-primary-spoke-vpc"
+  cidr = "10.30.0.0/16"
+
+  azs             = ["${local.primary_region}a", "${local.primary_region}b", "${local.primary_region}c"]
+  private_subnets = ["10.30.1.0/24", "10.30.2.0/24", "10.30.3.0/24"]
+
+  enable_ipv6                                    = true
+  private_subnet_assign_ipv6_address_on_creation = true
+  private_subnet_ipv6_prefixes                   = [6, 7, 8]
+
+  tags = local.tags
+}
+
+module "peer_spoke_vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  providers = {
+    aws = aws.peer_spoke
+  }
+
+  name = "${local.name}-peer-spoke-vpc"
+  cidr = "10.40.0.0/16"
+
+  azs             = ["${local.secondary_region}a", "${local.secondary_region}b", "${local.secondary_region}c"]
+  private_subnets = ["10.40.1.0/24", "10.40.2.0/24", "10.40.3.0/24"]
+
+  enable_ipv6                                    = true
+  private_subnet_assign_ipv6_address_on_creation = true
+  private_subnet_ipv6_prefixes                   = [9, 10, 11]
 
   tags = local.tags
 }

--- a/examples/multi-account/outputs.tf
+++ b/examples/multi-account/outputs.tf
@@ -1,100 +1,229 @@
 ################################################################################
-# Transit Gateway
+# Primary Hub Transit Gateway
 ################################################################################
 
-output "ec2_transit_gateway_arn" {
+output "primary_hub_ec2_transit_gateway_arn" {
   description = "EC2 Transit Gateway Amazon Resource Name (ARN)"
-  value       = module.tgw.ec2_transit_gateway_arn
+  value       = module.primary_hub.ec2_transit_gateway_arn
 }
 
-output "ec2_transit_gateway_id" {
+output "primary_hub_ec2_transit_gateway_id" {
   description = "EC2 Transit Gateway identifier"
-  value       = module.tgw.ec2_transit_gateway_id
+  value       = module.primary_hub.ec2_transit_gateway_id
 }
 
-output "ec2_transit_gateway_owner_id" {
+output "primary_hub_ec2_transit_gateway_owner_id" {
   description = "Identifier of the AWS account that owns the EC2 Transit Gateway"
-  value       = module.tgw.ec2_transit_gateway_owner_id
+  value       = module.primary_hub.ec2_transit_gateway_owner_id
 }
 
-output "ec2_transit_gateway_association_default_route_table_id" {
+output "primary_hub_ec2_transit_gateway_association_default_route_table_id" {
   description = "Identifier of the default association route table"
-  value       = module.tgw.ec2_transit_gateway_association_default_route_table_id
+  value       = module.primary_hub.ec2_transit_gateway_association_default_route_table_id
 }
 
-output "ec2_transit_gateway_propagation_default_route_table_id" {
+output "primary_hub_ec2_transit_gateway_propagation_default_route_table_id" {
   description = "Identifier of the default propagation route table"
-  value       = module.tgw.ec2_transit_gateway_propagation_default_route_table_id
+  value       = module.primary_hub.ec2_transit_gateway_propagation_default_route_table_id
 }
 
 ################################################################################
-# VPC Attachment
+# Primary Hub VPC Attachment
 ################################################################################
 
-output "ec2_transit_gateway_vpc_attachment_ids" {
+output "primary_hub_ec2_transit_gateway_vpc_attachment_ids" {
   description = "List of EC2 Transit Gateway VPC Attachment identifiers"
-  value       = module.tgw.ec2_transit_gateway_vpc_attachment_ids
+  value       = module.primary_hub.ec2_transit_gateway_vpc_attachment_ids
 }
 
-output "ec2_transit_gateway_vpc_attachment" {
+output "primary_hub_ec2_transit_gateway_vpc_attachment" {
   description = "Map of EC2 Transit Gateway VPC Attachment attributes"
-  value       = module.tgw.ec2_transit_gateway_vpc_attachment
+  value       = module.primary_hub.ec2_transit_gateway_vpc_attachment
 }
 
 ################################################################################
-# Route Table / Routes
+# Primary Hub Route Table / Routes
 ################################################################################
 
-output "ec2_transit_gateway_route_table_id" {
+output "primary_hub_ec2_transit_gateway_route_table_id" {
   description = "EC2 Transit Gateway Route Table identifier"
-  value       = module.tgw.ec2_transit_gateway_route_table_id
+  value       = module.primary_hub.ec2_transit_gateway_route_table_id
 }
 
-output "ec2_transit_gateway_route_table_default_association_route_table" {
+output "primary_hub_ec2_transit_gateway_route_table_default_association_route_table" {
   description = "Boolean whether this is the default association route table for the EC2 Transit Gateway"
-  value       = module.tgw.ec2_transit_gateway_route_table_default_association_route_table
+  value       = module.primary_hub.ec2_transit_gateway_route_table_default_association_route_table
 }
 
-output "ec2_transit_gateway_route_table_default_propagation_route_table" {
+output "primary_hub_ec2_transit_gateway_route_table_default_propagation_route_table" {
   description = "Boolean whether this is the default propagation route table for the EC2 Transit Gateway"
-  value       = module.tgw.ec2_transit_gateway_route_table_default_propagation_route_table
+  value       = module.primary_hub.ec2_transit_gateway_route_table_default_propagation_route_table
 }
 
-output "ec2_transit_gateway_route_ids" {
+output "primary_hub_ec2_transit_gateway_route_ids" {
   description = "List of EC2 Transit Gateway Route Table identifier combined with destination"
-  value       = module.tgw.ec2_transit_gateway_route_ids
+  value       = module.primary_hub.ec2_transit_gateway_route_ids
 }
 
-output "ec2_transit_gateway_route_table_association_ids" {
+output "primary_hub_ec2_transit_gateway_route_table_association_ids" {
   description = "List of EC2 Transit Gateway Route Table Association identifiers"
-  value       = module.tgw.ec2_transit_gateway_route_table_association_ids
+  value       = module.primary_hub.ec2_transit_gateway_route_table_association_ids
 }
 
-output "ec2_transit_gateway_route_table_association" {
+output "primary_hub_ec2_transit_gateway_route_table_association" {
   description = "Map of EC2 Transit Gateway Route Table Association attributes"
-  value       = module.tgw.ec2_transit_gateway_route_table_association
+  value       = module.primary_hub.ec2_transit_gateway_route_table_association
 }
 
-output "ec2_transit_gateway_route_table_propagation_ids" {
+output "primary_hub_ec2_transit_gateway_route_table_propagation_ids" {
   description = "List of EC2 Transit Gateway Route Table Propagation identifiers"
-  value       = module.tgw.ec2_transit_gateway_route_table_propagation_ids
+  value       = module.primary_hub.ec2_transit_gateway_route_table_propagation_ids
 }
 
-output "ec2_transit_gateway_route_table_propagation" {
+output "primary_hub_ec2_transit_gateway_route_table_propagation" {
   description = "Map of EC2 Transit Gateway Route Table Propagation attributes"
-  value       = module.tgw.ec2_transit_gateway_route_table_propagation
+  value       = module.primary_hub.ec2_transit_gateway_route_table_propagation
 }
 
 ################################################################################
-# Resource Access Manager
+# Primary Hub Resource Access Manager
 ################################################################################
 
-output "ram_resource_share_id" {
+output "primary_hub_ram_resource_share_id" {
   description = "The Amazon Resource Name (ARN) of the resource share"
-  value       = module.tgw.ram_resource_share_id
+  value       = module.primary_hub.ram_resource_share_id
 }
 
-output "ram_principal_association_id" {
+output "primary_hub_ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
-  value       = module.tgw.ram_principal_association_id
+  value       = module.primary_hub.ram_principal_association_id
+}
+
+################################################################################
+# Primary Spoke VPC Attachment
+################################################################################
+
+output "primary_spoke_ec2_transit_gateway_vpc_attachment_ids" {
+  description = "List of EC2 Transit Gateway VPC Attachment identifiers"
+  value       = module.primary_spoke.ec2_transit_gateway_vpc_attachment_ids
+}
+
+output "primary_spoke_ec2_transit_gateway_vpc_attachment" {
+  description = "Map of EC2 Transit Gateway VPC Attachment attributes"
+  value       = module.primary_spoke.ec2_transit_gateway_vpc_attachment
+}
+
+################################################################################
+# Peer Hub Transit Gateway
+################################################################################
+
+output "peer_hub_ec2_transit_gateway_arn" {
+  description = "EC2 Transit Gateway Amazon Resource Name (ARN)"
+  value       = module.peer_hub.ec2_transit_gateway_arn
+}
+
+output "peer_hub_ec2_transit_gateway_id" {
+  description = "EC2 Transit Gateway identifier"
+  value       = module.peer_hub.ec2_transit_gateway_id
+}
+
+output "peer_hub_ec2_transit_gateway_owner_id" {
+  description = "Identifier of the AWS account that owns the EC2 Transit Gateway"
+  value       = module.peer_hub.ec2_transit_gateway_owner_id
+}
+
+output "peer_hub_ec2_transit_gateway_association_default_route_table_id" {
+  description = "Identifier of the default association route table"
+  value       = module.peer_hub.ec2_transit_gateway_association_default_route_table_id
+}
+
+output "peer_hub_ec2_transit_gateway_propagation_default_route_table_id" {
+  description = "Identifier of the default propagation route table"
+  value       = module.peer_hub.ec2_transit_gateway_propagation_default_route_table_id
+}
+
+################################################################################
+# Peer Hub VPC Attachment
+################################################################################
+
+output "peer_hub_ec2_transit_gateway_vpc_attachment_ids" {
+  description = "List of EC2 Transit Gateway VPC Attachment identifiers"
+  value       = module.peer_hub.ec2_transit_gateway_vpc_attachment_ids
+}
+
+output "peer_hub_ec2_transit_gateway_vpc_attachment" {
+  description = "Map of EC2 Transit Gateway VPC Attachment attributes"
+  value       = module.peer_hub.ec2_transit_gateway_vpc_attachment
+}
+
+################################################################################
+# Peer Hub Route Table / Routes
+################################################################################
+
+output "peer_hub_ec2_transit_gateway_route_table_id" {
+  description = "EC2 Transit Gateway Route Table identifier"
+  value       = module.peer_hub.ec2_transit_gateway_route_table_id
+}
+
+output "peer_hub_ec2_transit_gateway_route_table_default_association_route_table" {
+  description = "Boolean whether this is the default association route table for the EC2 Transit Gateway"
+  value       = module.peer_hub.ec2_transit_gateway_route_table_default_association_route_table
+}
+
+output "peer_hub_ec2_transit_gateway_route_table_default_propagation_route_table" {
+  description = "Boolean whether this is the default propagation route table for the EC2 Transit Gateway"
+  value       = module.peer_hub.ec2_transit_gateway_route_table_default_propagation_route_table
+}
+
+output "peer_hub_ec2_transit_gateway_route_ids" {
+  description = "List of EC2 Transit Gateway Route Table identifier combined with destination"
+  value       = module.peer_hub.ec2_transit_gateway_route_ids
+}
+
+output "peer_hub_ec2_transit_gateway_route_table_association_ids" {
+  description = "List of EC2 Transit Gateway Route Table Association identifiers"
+  value       = module.peer_hub.ec2_transit_gateway_route_table_association_ids
+}
+
+output "peer_hub_ec2_transit_gateway_route_table_association" {
+  description = "Map of EC2 Transit Gateway Route Table Association attributes"
+  value       = module.peer_hub.ec2_transit_gateway_route_table_association
+}
+
+output "peer_hub_ec2_transit_gateway_route_table_propagation_ids" {
+  description = "List of EC2 Transit Gateway Route Table Propagation identifiers"
+  value       = module.peer_hub.ec2_transit_gateway_route_table_propagation_ids
+}
+
+output "peer_hub_ec2_transit_gateway_route_table_propagation" {
+  description = "Map of EC2 Transit Gateway Route Table Propagation attributes"
+  value       = module.peer_hub.ec2_transit_gateway_route_table_propagation
+}
+
+################################################################################
+# Peer Hub Resource Access Manager
+################################################################################
+
+output "peer_hub_ram_resource_share_id" {
+  description = "The Amazon Resource Name (ARN) of the resource share"
+  value       = module.peer_hub.ram_resource_share_id
+}
+
+output "peer_hub_ram_principal_association_id" {
+  description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
+  value       = module.peer_hub.ram_principal_association_id
+}
+
+################################################################################
+# Peer Spoke VPC Attachment
+################################################################################
+
+output "peer_spoke_ec2_transit_gateway_vpc_attachment_ids" {
+  description = "List of EC2 Transit Gateway VPC Attachment identifiers"
+  value       = module.peer_spoke.ec2_transit_gateway_vpc_attachment_ids
+}
+
+output "peer_spoke_ec2_transit_gateway_vpc_attachment" {
+  description = "Map of EC2 Transit Gateway VPC Attachment attributes"
+  value       = module.peer_spoke.ec2_transit_gateway_vpc_attachment
 }

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "aws_ec2_tag" "this" {
 ################################################################################
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
-  for_each = var.vpc_attachments
+  for_each = { for k, v in var.attachments : k => v if v.attachment_type == "vpc" && try(v.create_vpc_attachment, false) }
 
   transit_gateway_id = var.create_tgw ? aws_ec2_transit_gateway.this[0].id : each.value.tgw_id
   vpc_id             = each.value.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -270,9 +270,9 @@ resource "aws_ram_resource_association" "this" {
 }
 
 resource "aws_ram_principal_association" "this" {
-  count = var.create_tgw && var.share_tgw ? length(var.ram_principals) : 0
+  for_each = var.create_tgw && var.share_tgw ? var.ram_principals : []
 
-  principal          = var.ram_principals[count.index]
+  principal          = each.value
   resource_share_arn = aws_ram_resource_share.this[0].arn
 }
 

--- a/main.tf
+++ b/main.tf
@@ -184,13 +184,13 @@ resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "this" {
 ################################################################################
 
 resource "aws_ec2_transit_gateway_route_table" "this" {
-  count = var.create_tgw ? 1 : 0
+  for_each = var.create_tgw ? var.tgw_route_tables : toset([])
 
   transit_gateway_id = aws_ec2_transit_gateway.this[0].id
 
   tags = merge(
     var.tags,
-    { Name = var.name },
+    { Name = "${var.name}-${each.key}" },
     var.tgw_route_table_tags,
   )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -62,7 +62,7 @@ output "ec2_transit_gateway_route_table_default_propagation_route_table" {
 
 output "ec2_transit_gateway_route_ids" {
   description = "List of EC2 Transit Gateway Route Table identifier combined with destination"
-  value       = aws_ec2_transit_gateway_route.this[*].id
+  value       = tomap({ for k, route in aws_ec2_transit_gateway_route.this : k => route.id })
 }
 
 output "ec2_transit_gateway_route_table_association_ids" {
@@ -96,5 +96,5 @@ output "ram_resource_share_id" {
 
 output "ram_principal_association_id" {
   description = "The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma"
-  value       = try(aws_ram_principal_association.this[0].id, "")
+  value       = [for k, v in aws_ram_principal_association.this : v.id]
 }

--- a/tgw-flow-logs.tf
+++ b/tgw-flow-logs.tf
@@ -1,0 +1,37 @@
+resource "aws_flow_log" "this" {
+  for_each = { for k, v in var.flow_logs : "${v.key}-${v.dest_type}" => v if v.dest_enabled }
+
+  log_destination_type = each.value.dest_type
+  log_destination = {
+    s3               = each.value.s3_dest_arn,
+    cloud-watch-logs = each.value.cloudwatch_dest_arn
+  }[each.value.dest_type]
+  log_format         = try(each.value.log_format, null)
+  iam_role_arn       = each.value.dest_type == "cloud-watch-logs" ? each.value.cloudwatch_iam_role_arn : null
+  traffic_type       = try(each.value.traffic_type, "ALL")
+  transit_gateway_id = each.value.key == "tgw" && var.create_tgw ? aws_ec2_transit_gateway.this[0].id : null
+  transit_gateway_attachment_id = each.value.key != "tgw" ? lookup({
+    vpc     = each.value.create_vpc_attachment ? aws_ec2_transit_gateway_vpc_attachment.this[each.value.key].id : null
+    peering = each.value.create_tgw_peering ? aws_ec2_transit_gateway_peering_attachment.this[each.value.key].id : null
+  }, each.value.attachment_type, null) : null
+  # When transit_gateway_id or transit_gateway_attachment_id is specified, max_aggregation_interval must be 60 seconds (1 minute).
+  max_aggregation_interval = 60
+
+  dynamic "destination_options" {
+    for_each = each.value.dest_type == "s3" ? [true] : []
+
+    content {
+      file_format                = try(each.value.file_format, "parquet")
+      hive_compatible_partitions = try(each.value.hive_compatible_partitions, false)
+      per_hour_partition         = try(each.value.per_hour_partition, true)
+    }
+  }
+
+  tags = merge(var.tags, var.tgw_flow_log_tags)
+
+  depends_on = [
+    aws_ec2_transit_gateway.this,
+    aws_ec2_transit_gateway_peering_attachment.this,
+    data.aws_ec2_transit_gateway_vpc_attachment.this,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -169,3 +169,19 @@ variable "ram_tags" {
   type        = map(string)
   default     = {}
 }
+
+################################################################################
+# Flow Logs
+################################################################################
+
+variable "flow_logs" {
+  description = "Flow Logs to create for Transit Gateway or attachments"
+  type        = any
+  default     = {}
+}
+
+variable "tgw_flow_log_tags" {
+  description = "Additional tags for TGW or attachment flow logs"
+  type        = map(string)
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -96,13 +96,13 @@ variable "tgw_default_route_table_tags" {
 # VPC Attachment
 ################################################################################
 
-variable "vpc_attachments" {
+variable "attachments" {
   description = "Maps of maps of VPC details to attach to TGW. Type 'any' to disable type validation by Terraform."
   type        = any
   default     = {}
 }
 
-variable "tgw_vpc_attachment_tags" {
+variable "tgw_attachment_tags" {
   description = "Additional tags for VPC attachments"
   type        = map(string)
   default     = {}
@@ -122,6 +122,12 @@ variable "tgw_route_table_tags" {
   description = "Additional tags for the TGW route table"
   type        = map(string)
   default     = {}
+}
+
+variable "tgw_route_tables" {
+  description = "Custom TGW route tables to create"
+  type        = set(string)
+  default     = ["custom"]
 }
 
 ################################################################################
@@ -148,7 +154,7 @@ variable "ram_allow_external_principals" {
 
 variable "ram_principals" {
   description = "A list of principals to share TGW with. Possible values are an AWS account ID, an AWS Organizations Organization ARN, or an AWS Organizations Organization Unit ARN"
-  type        = list(string)
+  type        = set(string)
   default     = []
 }
 


### PR DESCRIPTION
## Description
* Add an "accepter" resource for VPC attachments, to avoid the "auto accept shared attachments" feature when using Resource Access Manager (RAM)
* Add support for TGW Peering attachments
* Add Flow Logs for whole-TGW and/or individual TGW Peering/VPC attachments, publishing to S3 and/or CloudWatch Logs
* Convert tgw_routes from a list of maps to a map of maps, to avoid potential downtime associated with destroying routes when adding new ones
* Enable multiple TGW route tables to allow for more granular network segmentation
* Allow for adding multiple CIDR blocks to VPC route tables per-attachment, and rename the parameter from tgw_destination_cidrs to vpc_route_table_destination_cidrs to reflect its true purpose
* Add parameters to help transform implementation steps into a more cohesive order of operations
* Convert TGW route destination CIDR block to list, to allow multiple CIDR blocks per attachment
* Allow for disabling non-default route table propagation, to ensure VPC CIDR block can be left out of TGW route table when only certain subnets should be routable
## Motivation and Context
This module was missing quite a few features that are necessary for true multi-account operation, as well as operational concerns like logging.

Fixes:
https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/pull/95
https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/pull/102

## Breaking Changes
This PR includes breaking changes due to changes in data structures.  The changes to data structures (converting lists/sets to maps, mostly) were necessary to prevent downtime during applies due to deleting/re-creating routes.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

I am running my refactor in production currently, using one AWS account as the hub, and several other AWS accounts as the spokes.
