### PR TITLE
feat: Do not create the resource aws_ram_resource_share_accepter if R…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ resource "aws_ram_principal_association" "this" {
 }
 
 resource "aws_ram_resource_share_accepter" "this" {
-  count = !var.create_tgw && var.share_tgw ? 1 : 0
+  count = !var.create_tgw && var.share_tgw && !var.ram_sharing_organization_enabled ? 1 : 0
 
   share_arn = var.ram_resource_share_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -163,3 +163,9 @@ variable "ram_tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "ram_sharing_organization_enabled" {
+  description = "Whether or not the sharing of resource within your organization is enabled"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
…AM Sharing with AWS Organizations is enabled

## Description
Add an extra variable to the module to prevent the creation of an unnecessary resource if RAM Sharing with AWS Organizations is enabled. 

## Issues
Related to #116 