### PR TITLE
Core 2711

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for index, x in local.vpc_route_table_destination_cidr : x.vpc_attachment_id + "-" + x.rtb_id => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
+  for_each = { for index, x in local.vpc_route_table_destination_cidr : x.vpc_attachment_id + x.rtb_id => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for x in local.vpc_route_table_destination_cidr : x => { "rtb_id" : x.rtb_id, "cidr" : x.cidr } }
+  for_each = { for index, x in local.vpc_route_table_destination_cidr : index => { "rtb_id" : x.rtb_id, "cidr" : x.cidr } }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for x in local.vpc_route_table_destination_cidr : x.tgw_id => { "rtb_id" : x.rtb_id, "cidr" : x.cidr } }
+  for_each = { for x in local.vpc_route_table_destination_cidr : x.cidr => { "rtb_id" : x.rtb_id, "cidr" : x.cidr } }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for index, x in local.vpc_route_table_destination_cidr : x.vpc_attachment_id + x.rtb_id => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
+  for_each = { for index, x in local.vpc_route_table_destination_cidr : x.rtb_id => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr

--- a/main.tf
+++ b/main.tf
@@ -111,11 +111,11 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for index, x in local.vpc_route_table_destination_cidr : index => { "rtb_id" : x.rtb_id, "cidr" : x.cidr } }
+  for_each = { for index, x in local.vpc_route_table_destination_cidr : index => { "rtb_id" : x.rtb_id, "cidr" : x.cidr , "tgw_id": x.tgw_id} }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr
-  transit_gateway_id     = var.create_tgw ? aws_ec2_transit_gateway.this[0].id : each.key
+  transit_gateway_id     = var.create_tgw ? aws_ec2_transit_gateway.this[0].id : each.value.tgw_id
 }
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for x in local.vpc_route_table_destination_cidr : x.cidr => { "rtb_id" : x.rtb_id, "cidr" : x.cidr } }
+  for_each = { for x in local.vpc_route_table_destination_cidr : x => { "rtb_id" : x.rtb_id, "cidr" : x.cidr } }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for index, x in local.vpc_route_table_destination_cidr : "${x.rtb_id}-${x.cidr}" => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
+  for_each = { for index, x in local.vpc_route_table_destination_cidr : "${x.tgw_id}-${x.rtb_id}-${x.cidr}" => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for index, x in local.vpc_route_table_destination_cidr : x.rtb_id => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
+  for_each = { for index, x in local.vpc_route_table_destination_cidr : "${x.rtb_id}-${x.cidr}" => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr

--- a/main.tf
+++ b/main.tf
@@ -13,9 +13,10 @@ locals {
   vpc_route_table_destination_cidr = flatten([
     for k, v in var.vpc_attachments : [
       for rtb_id in try(v.vpc_route_table_ids, []) : {
-        rtb_id = rtb_id
-        cidr   = v.tgw_destination_cidr
-        tgw_id = v.tgw_id
+        vpc_attachment_id = k
+        rtb_id            = rtb_id
+        cidr              = v.tgw_destination_cidr
+        tgw_id            = v.tgw_id
       }
     ]
   ])
@@ -111,7 +112,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for index, x in local.vpc_route_table_destination_cidr : index => { "rtb_id" : x.rtb_id, "cidr" : x.cidr , "tgw_id": x.tgw_id} }
+  for_each = { for index, x in local.vpc_route_table_destination_cidr : x.vpc_attachment_id => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr

--- a/main.tf
+++ b/main.tf
@@ -12,12 +12,14 @@ locals {
 
   vpc_route_table_destination_cidr = flatten([
     for k, v in var.vpc_attachments : [
-      for rtb_id in try(v.vpc_route_table_ids, []) : {
-        vpc_attachment_id = k
-        rtb_id            = rtb_id
-        cidr              = v.tgw_destination_cidr
-        tgw_id            = v.tgw_id
-      }
+      for rtb_id in try(v.vpc_route_table_ids, []) : [
+        for tgw_route in try(v.tgw_routes, []) : {
+          vpc_attachment_id = k
+          rtb_id            = rtb_id
+          cidr              = tgw_route.destination_cidr_block
+          tgw_id            = v.tgw_id
+        }
+      ]
     ]
   ])
 }

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
-  for_each = { for index, x in local.vpc_route_table_destination_cidr : x.vpc_attachment_id => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
+  for_each = { for index, x in local.vpc_route_table_destination_cidr : x.vpc_attachment_id + "-" + x.rtb_id => { "rtb_id" : x.rtb_id, "cidr" : x.cidr, "tgw_id" : x.tgw_id } }
 
   route_table_id         = each.value.rtb_id
   destination_cidr_block = each.value.cidr

--- a/variables.tf
+++ b/variables.tf
@@ -163,3 +163,27 @@ variable "ram_tags" {
   type        = map(string)
   default     = {}
 }
+
+################################################################################
+# TGW Peering Settings
+################################################################################
+variable "tgw_peering_attachments" {
+  description = "A map of transit gateway peering attachments"
+  type = map(object({
+    peer_transit_gateway_id = string
+    peer_region             = string
+    peer_account_id         = string
+    request_accepter        = bool
+  }))
+  default = {}
+}
+
+variable "tgw_peering_route_table_routes" {
+  description = "A list of routes for the Transit Gateway Peering Route Table"
+  type = list(object({
+    destination_cidr_block = string
+    peering_attachment_key = string
+  }))
+  default = []
+}
+


### PR DESCRIPTION
## Description
Added new resources and configurations related to Transit Gateway (TGW) Peering in `main.tf`. This includes the creation of TGW Peering Attachments, accepting Peering Attachments, and setting up a Transit Gateway Peering Route Table along with associated routes. Additionally, added corresponding variables in `variables.tf` for TGW Peering Settings including peering attachments and route table routes.

## Motivation and Context
This change allows for the setup and management of Transit Gateway Peering, which is essential for facilitating network connectivity across different AWS accounts and regions.

## Breaking Changes
The changes do not break backward compatibility. They introduce new functionality for handling TGW Peering.
