### PR TITLE
allow override of tgw route table association

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "this" {
 
   # Create association if it was not set already by aws_ec2_transit_gateway_vpc_attachment resource
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
-  transit_gateway_route_table_id = var.create_tgw ? aws_ec2_transit_gateway_route_table.this[0].id : try(each.value.transit_gateway_route_table_id, var.transit_gateway_route_table_id)
+  transit_gateway_route_table_id = try(each.value.transit_gateway_route_table_id, var.create_tgw ? aws_ec2_transit_gateway_route_table.this[0].id : var.transit_gateway_route_table_id)
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {


### PR DESCRIPTION
## Description
Allow override of TGW route table association

## Motivation and Context
It seems that the `for_each` in resource `aws_ec2_transit_gateway_route_table_association.this` is dependent on `var.create_tgw` so that it only iterates if `var.create_tgw` is true.

If that is the case, then the `transit_gateway_route_table_id` property can only be set to `aws_ec2_transit_gateway_route_table.this[0].id` and the intended override by `each.value.transit_gateway_route_table_id` can never be reached.

## How Has This Been Tested?
- untested in the context of the module
- only tested on a local project