### PR TITLE
fix: Defined dependencies: RAM_share_accepter<-TGW<-AWS_route

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,8 @@ resource "aws_ec2_tag" "this" {
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   for_each = var.vpc_attachments
 
+  depends_on = [ aws_ram_resource_share_accepter.this ]
+
   transit_gateway_id = var.create_tgw ? aws_ec2_transit_gateway.this[0].id : each.value.tgw_id
   vpc_id             = each.value.vpc_id
   subnet_ids         = each.value.subnet_ids
@@ -111,6 +113,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
 }
 
 resource "aws_route" "this" {
+  depends_on = [ aws_ec2_transit_gateway_vpc_attachment.this ]
   for_each = { for x in local.vpc_route_table_destination_cidr : x.rtb_id => {
     cidr   = x.cidr,
     tgw_id = x.tgw_id


### PR DESCRIPTION


## Description
Defined dependencies: `aws_ram_resource_share_accepter`<-`aws_ec2_transit_gateway_vpc_attachment`<-`aws_route.this`

## Motivation and Context
I was using this module to wire the transit gateway from one account to another (peer account) and the code fails to create route table in peer VPC because of the missing resource ordering. It creates route table in peering VPC before accepting the RAM share and TGW attachment to the VPC.

Terragrunt apply fails with the following error:
```bash
module.tgw.aws_route.this["rtb-111111"]: Still creating... [4m50s elapsed]
╷
│ Error: creating EC2 Transit Gateway VPC Attachment: InvalidTransitGatewayID.NotFound: Transit Gateway tgw-111111111 was deleted or does not exist.
│ 	status code: 400, request id: 92dda22e-9e61-43e6-bab7-e2fe1744f0d0
│ 
│   with module.tgw.aws_ec2_transit_gateway_vpc_attachment.this["dev"],
│   on .terraform/modules/tgw/main.tf line 66, in resource "aws_ec2_transit_gateway_vpc_attachment" "this":
│   66: resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
│ 
╵
╷
│ Error: creating Route in Route Table (rtb-111111) with destination (0.0.0.0/0): InvalidTransitGatewayID.NotFound: The transitGateway ID 'tgw-08c63a2acff677f14' does not exist.
│ 	status code: 400, request id: 5ac5d791-8be1-474e-b625-a3bf95cc369b
│ 
│   with module.tgw.aws_route.this["rtb-111111"],
│   on .terraform/modules/tgw/main.tf line 113, in resource "aws_route" "this":
│  113: resource "aws_route" "this" {
```

## Breaking Changes
No.

## How Has This Been Tested?
- The `examples/*` should not be updated
- I build my case using the examples and tested it by creating TGW in shared AWS account (`#1`) with subsequent apply to DEV AWS account (`#2` - peer).
Here is the order how resources are being created in peering account:
```bash
module.tgw.aws_ram_resource_share_accepter.this[0]: Creating...
module.tgw.aws_ram_resource_share_accepter.this[0]: Creation complete after 4s [id=arn:aws:ram:us-west-1:11111111:resource-share/111111]
module.tgw.aws_ec2_transit_gateway_vpc_attachment.this["dev"]: Creating...
module.tgw.aws_ec2_transit_gateway_vpc_attachment.this["dev"]: Still creating... [10s elapsed]
...
module.tgw.aws_ec2_transit_gateway_vpc_attachment.this["dev"]: Still creating... [1m40s elapsed]
module.tgw.aws_ec2_transit_gateway_vpc_attachment.this["dev"]: Creation complete after 1m48s [id=tgw-attach-1111]
module.tgw.aws_route.this["rtb-1111"]: Creating...
module.tgw.aws_route.this["rtb-1111"]: Creating...
module.tgw.aws_route.this["rtb-1111"]: Creation complete after 2s [id=r-rtb-1111]
```
- I have executed `pre-commit run -a` on my pull request

p.s.: putin - Huilo.
