### PR TITLE
feat: Allow specifying additional TGW routes in attached VPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ No modules.
 | [aws_ram_resource_share.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share) | resource |
 | [aws_ram_resource_share_accepter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share_accepter) | resource |
 | [aws_route.additional_cidrs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
-| [aws_route.destination_cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ No modules.
 | [aws_ram_resource_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_association) | resource |
 | [aws_ram_resource_share.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share) | resource |
 | [aws_ram_resource_share_accepter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_share_accepter) | resource |
-| [aws_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.additional_cidrs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.destination_cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 
 ## Inputs
 

--- a/examples/multi-account/main.tf
+++ b/examples/multi-account/main.tf
@@ -111,7 +111,8 @@ module "tgw_peer" {
       transit_gateway_default_route_table_propagation = false
 
       vpc_route_table_ids  = module.vpc1.private_route_table_ids
-      tgw_destination_cidr = "0.0.0.0/0"
+      tgw_destination_cidr = "10.0.0.0/8"
+      tgw_additional_cidrs = ["172.0.0/12"]
 
       tgw_routes = [
         {

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,18 @@ locals {
       }
     ]
   ])
+
+  vpc_route_table_additional_cidrs = flatten([
+    for k, v in var.vpc_attachments : [
+      for rtb_id in try(v.vpc_route_table_ids, []) : [
+        for cidr in try(v.tgw_additional_cidrs, []) : {
+          rtb_id = rtb_id
+          cidr   = cidr
+          tgw_id = var.create_tgw ? aws_ec2_transit_gateway.this[0].id : v.tgw_id
+        }
+      ]
+    ]
+  ])
 }
 
 ################################################################################
@@ -127,7 +139,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
   transit_gateway_attachment_id  = tobool(try(local.vpc_attachments_with_routes[count.index][1].blackhole, false)) == false ? aws_ec2_transit_gateway_vpc_attachment.this[local.vpc_attachments_with_routes[count.index][0].key].id : null
 }
 
-resource "aws_route" "this" {
+resource "aws_route" "destination_cidr" {
   for_each = { for x in local.vpc_route_table_destination_cidr : x.rtb_id => {
     cidr   = x.cidr,
     tgw_id = x.tgw_id
@@ -141,6 +153,24 @@ resource "aws_route" "this" {
   transit_gateway_id          = each.value["tgw_id"]
 
   depends_on = [aws_ec2_transit_gateway_vpc_attachment.this]
+}
+
+moved {
+  from = aws_route.this
+  to   = aws_route.destination_cidr
+}
+
+resource "aws_route" "additional_cidrs" {
+  for_each = { for x in local.vpc_route_table_additional_cidrs : "${x.rtb_id}_${x.cidr}" => {
+    cidr   = x.cidr
+    rtb_id = x.rtb_id
+    tgw_id = x.tgw_id
+  } }
+
+  route_table_id              = each.value["rtb_id"]
+  destination_cidr_block      = try(each.value.ipv6_support, false) ? null : each.value["cidr"]
+  destination_ipv6_cidr_block = try(each.value.ipv6_support, false) ? each.value["cidr"] : null
+  transit_gateway_id          = each.value["tgw_id"]
 }
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
   transit_gateway_attachment_id  = tobool(try(local.vpc_attachments_with_routes[count.index][1].blackhole, false)) == false ? aws_ec2_transit_gateway_vpc_attachment.this[local.vpc_attachments_with_routes[count.index][0].key].id : null
 }
 
-resource "aws_route" "destination_cidr" {
+resource "aws_route" "this" {
   for_each = { for x in local.vpc_route_table_destination_cidr : x.rtb_id => {
     cidr   = x.cidr,
     tgw_id = x.tgw_id
@@ -153,11 +153,6 @@ resource "aws_route" "destination_cidr" {
   transit_gateway_id          = each.value["tgw_id"]
 
   depends_on = [aws_ec2_transit_gateway_vpc_attachment.this]
-}
-
-moved {
-  from = aws_route.this
-  to   = aws_route.destination_cidr
 }
 
 resource "aws_route" "additional_cidrs" {


### PR DESCRIPTION
## Description
Adds parameter `tgw_additional_vpc_cidrs` to the `vpc_attachments` map that enables adding additional `aws_route` resources that send traffic across the TGW VPC attachment.

Changes the name of the existing `aws_route` resource from `this` since there are now more than one in the state file.

## Motivation and Context
In our environment we have two CIDR blocks that need to transit from the VPC across the TGW network: `10.0.0.0/8` and `172.16.0.0/12`. Unfortunately this is not possible to do with the module as it is today.

With this change we can add `aws_route` entries for both CIDR blocks to our VPC route tables.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
In order to implement this I had to add a second `aws_route` resource because the existing one is keyed only on route table ID which is no longer a unique value for route resources.

Commonly accepted Terraform style rules indicate that `this` is only an acceptable resource name if it is the only one of its type in a module. Since there are now two `aws_route` resources, I changed the name of the existing `this` resource to `destination_cidr` so that this style rule is still valid.

While I personally feel that the this is the correct approach, if renaming the resource is undesirable I would fine with reverting the resource rename.


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
