### PR TITLE
feat: Add support for security group referencing to transit-gateway module

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ No modules.
 | <a name="input_enable_default_route_table_propagation"></a> [enable\_default\_route\_table\_propagation](#input\_enable\_default\_route\_table\_propagation) | Whether resource attachments automatically propagate routes to the default propagation route table | `bool` | `true` | no |
 | <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | Should be true to enable DNS support in the TGW | `bool` | `true` | no |
 | <a name="input_enable_multicast_support"></a> [enable\_multicast\_support](#input\_enable\_multicast\_support) | Whether multicast support is enabled | `bool` | `false` | no |
+| <a name="input_enable_sg_referencing_support"></a> [enable\_sg\_referencing\_support](#input\_enable\_sg\_referencing\_support) | Indicates whether to enable security group referencing support | `bool` | `true` | no |
 | <a name="input_enable_vpn_ecmp_support"></a> [enable\_vpn\_ecmp\_support](#input\_enable\_vpn\_ecmp\_support) | Whether VPN Equal Cost Multipath Protocol support is enabled | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier | `string` | `""` | no |
 | <a name="input_ram_allow_external_principals"></a> [ram\_allow\_external\_principals](#input\_ram\_allow\_external\_principals) | Indicates whether principals outside your organization can be associated with a resource share. | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,6 +29,9 @@ module "tgw" {
   # When "true" there is no need for RAM resources if using multiple AWS accounts
   enable_auto_accept_shared_attachments = true
 
+  # When "true", SG referencing support is enabled at the Transit Gateway level
+  enable_sg_referencing_support = true
+
   # When "true", allows service discovery through IGMP
   enable_multicast_support = false
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -34,10 +34,11 @@ module "tgw" {
 
   vpc_attachments = {
     vpc1 = {
-      vpc_id       = module.vpc1.vpc_id
-      subnet_ids   = module.vpc1.private_subnets
-      dns_support  = true
-      ipv6_support = true
+      vpc_id                             = module.vpc1.vpc_id
+      subnet_ids                         = module.vpc1.private_subnets
+      security_group_referencing_support = true
+      dns_support                        = true
+      ipv6_support                       = true
 
       transit_gateway_default_route_table_association = false
       transit_gateway_default_route_table_propagation = false

--- a/main.tf
+++ b/main.tf
@@ -28,15 +28,16 @@ locals {
 resource "aws_ec2_transit_gateway" "this" {
   count = var.create_tgw ? 1 : 0
 
-  description                     = coalesce(var.description, var.name)
-  amazon_side_asn                 = var.amazon_side_asn
-  default_route_table_association = var.enable_default_route_table_association ? "enable" : "disable"
-  default_route_table_propagation = var.enable_default_route_table_propagation ? "enable" : "disable"
-  auto_accept_shared_attachments  = var.enable_auto_accept_shared_attachments ? "enable" : "disable"
-  multicast_support               = var.enable_multicast_support ? "enable" : "disable"
-  vpn_ecmp_support                = var.enable_vpn_ecmp_support ? "enable" : "disable"
-  dns_support                     = var.enable_dns_support ? "enable" : "disable"
-  transit_gateway_cidr_blocks     = var.transit_gateway_cidr_blocks
+  description                        = coalesce(var.description, var.name)
+  amazon_side_asn                    = var.amazon_side_asn
+  default_route_table_association    = var.enable_default_route_table_association ? "enable" : "disable"
+  default_route_table_propagation    = var.enable_default_route_table_propagation ? "enable" : "disable"
+  auto_accept_shared_attachments     = var.enable_auto_accept_shared_attachments ? "enable" : "disable"
+  multicast_support                  = var.enable_multicast_support ? "enable" : "disable"
+  vpn_ecmp_support                   = var.enable_vpn_ecmp_support ? "enable" : "disable"
+  dns_support                        = var.enable_dns_support ? "enable" : "disable"
+  transit_gateway_cidr_blocks        = var.transit_gateway_cidr_blocks
+  security_group_referencing_support = var.enable_sg_referencing_support ? "enable" : "disable"
 
   timeouts {
     create = try(var.timeouts.create, null)

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   dns_support                                     = try(each.value.dns_support, true) ? "enable" : "disable"
   ipv6_support                                    = try(each.value.ipv6_support, false) ? "enable" : "disable"
   appliance_mode_support                          = try(each.value.appliance_mode_support, false) ? "enable" : "disable"
+  security_group_referencing_support              = try(each.value.security_group_referencing_support, false) ? "enable" : "disable"
   transit_gateway_default_route_table_association = try(each.value.transit_gateway_default_route_table_association, true)
   transit_gateway_default_route_table_propagation = try(each.value.transit_gateway_default_route_table_propagation, true)
 

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,12 @@ variable "tgw_default_route_table_tags" {
   default     = {}
 }
 
+variable "enable_sg_referencing_support" {
+  description = "Indicates whether to enable security group referencing support"
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # VPC Attachment
 ################################################################################


### PR DESCRIPTION
…odule

Added support for **security_group_referencing_support** in the **transit-gateway** module.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
AWS recently introduced [[HERE](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-security-group-referencing-for-aws-transit-gateway/)] security group referencing for Transit Gateway VPC attachments. This feature was available in the standalone resource `aws_ec2_transit_gateway_vpc_attachment` but not in the `transit-gateway` module. Added support for it in the module.

## Breaking Changes
no

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
