### PR TITLE
fix: Adjust aws provider requirements.

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.4"
+      version = ">= 5.69"
     }
   }
 }


### PR DESCRIPTION
## Description
Using [security_group_referencing_support](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/pull/133) added in release [2.13.0](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/releases/tag/v2.13.0) requires at least aws provider [v5.69.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.69.0).

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/issues/137

## Breaking Changes
NEW: Yes, it's a breaking change, the issue is [v2.13.0](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/releases/tag/v2.13.0) does not work without it. Feel free to takeover this PR.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
