### PR TITLE
feat: Add multiple destination cidrs support for vpc attachments

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -103,9 +103,23 @@ variable "enable_sg_referencing_support" {
 ################################################################################
 
 variable "vpc_attachments" {
-  description = "Maps of maps of VPC details to attach to TGW. Type 'any' to disable type validation by Terraform."
-  type        = any
-  default     = {}
+  description = "Maps of VPC names to VPC attachment configurations"
+  type = map(object({
+    vpc_id                                          = string
+    subnet_ids                                      = list(string)
+    dns_support                                     = optional(bool, true)
+    ipv6_support                                    = optional(bool, false)
+    appliance_mode_support                          = optional(bool, false)
+    security_group_referencing_support              = optional(bool, false)
+    transit_gateway_default_route_table_association = optional(bool, true)
+    transit_gateway_default_route_table_propagation = optional(bool, true)
+    vpc_route_table_ids                             = optional(list(string), [])
+    tgw_destination_cidrs                           = optional(list(string), [])
+    tgw_id                                          = optional(string)
+    tags                                            = optional(map(string), {})
+    tgw_routes                                      = optional(list(map(string)), [])
+  }))
+  default = {}
 }
 
 variable "tgw_vpc_attachment_tags" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add multiple destination cidrs support for vpc attachments (replace string with list)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We mostly need to set more than one routes for each VPC attachment, current only one as string is supported

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
