### PR TITLE
fix: Defined dependencies for aws_ram_resource_share_accepter and aws_route

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.4"
+    }
+  }
+}


### PR DESCRIPTION
## Description
Defined dependencies: aws_ram_resource_share_accepter<-aws_ec2_transit_gateway_vpc_attachment<-aws_route.this

## Motivation and Context
I was using this module to wire the transit gateway from one account to another (peer account) and the code fails to create route table in peer VPC because of the missing resource ordering. It creates route table in peering VPC before accepting the RAM share and TGW attachment to the VPC.

Terragrunt apply fails with the following error:
```
module.tgw.aws_route.this["rtb-111111"]: Still creating... [4m50s elapsed]
╷
│ Error: creating EC2 Transit Gateway VPC Attachment: InvalidTransitGatewayID.NotFound: Transit Gateway tgw-111111111 was deleted or does not exist.
│ 	status code: 400, request id: 92dda22e-9e61-43e6-bab7-e2fe1744f0d0
│ 
│   with module.tgw.aws_ec2_transit_gateway_vpc_attachment.this["dev"],
│   on .terraform/modules/tgw/main.tf line 66, in resource "aws_ec2_transit_gateway_vpc_attachment" "this":
│   66: resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
│ 
╵
╷
│ Error: creating Route in Route Table (rtb-111111) with destination (0.0.0.0/0): InvalidTransitGatewayID.NotFound: The transitGateway ID 'tgw-08c63a2acff677f14' does not exist.
│ 	status code: 400, request id: 5ac5d791-8be1-474e-b625-a3bf95cc369b
│ 
│   with module.tgw.aws_route.this["rtb-111111"],
│   on .terraform/modules/tgw/main.tf line 113, in resource "aws_route" "this":
│  113: resource "aws_route" "this" {
```

## Breaking Changes
No.

## How Has This Been Tested?
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I tested my changes on 2 customer projects with terragrunt where I was creating the transit gateway in networking account and shared it with 5 other accounts. Without this dependencies definition the terragrunt was failing with the error I mentioned initially.
