### PR TITLE
feat: Use attachment map key value as name suffix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 
   tags = merge(
     var.tags,
-    { Name = var.name },
+    { Name = "${var.name}-${each.key}" },
     var.tgw_vpc_attachment_tags,
     try(each.value.tags, {}),
   )
@@ -110,7 +110,7 @@ resource "aws_ec2_transit_gateway_route_table" "this" {
 
   tags = merge(
     var.tags,
-    { Name = var.name },
+    { Name = "${var.name}-${each.key}" },
     var.tgw_route_table_tags,
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ resource "aws_ec2_transit_gateway_route_table" "this" {
 
   tags = merge(
     var.tags,
-    { Name = "${var.name}-${each.key}" },
+    { Name = var.name },
     var.tgw_route_table_tags,
   )
 }


### PR DESCRIPTION
## Description
Simple change to remove repetition of same name for attachments and provide meaningful names based on the key used in the attachment map

## Motivation and Context
Simple organization instead of bluntly same resource name

## Breaking Changes
no

## How Has This Been Tested?
Executed change locally against environment with resources previously  created  with the module without the change
