### PR TITLE
feat: Add variable to enable encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ No modules.
 | <a name="input_enable_default_route_table_association"></a> [enable\_default\_route\_table\_association](#input\_enable\_default\_route\_table\_association) | Whether resource attachments are automatically associated with the default association route table | `bool` | `true` | no |
 | <a name="input_enable_default_route_table_propagation"></a> [enable\_default\_route\_table\_propagation](#input\_enable\_default\_route\_table\_propagation) | Whether resource attachments automatically propagate routes to the default propagation route table | `bool` | `true` | no |
 | <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | Should be true to enable DNS support in the TGW | `bool` | `true` | no |
+| <a name="input_enable_encryption_support"></a> [enable\_encryption\_support](#input\_enable\_encryption\_support) | Should be true to enable encryption support in the TGW | `bool` | `false` | no |
 | <a name="input_enable_multicast_support"></a> [enable\_multicast\_support](#input\_enable\_multicast\_support) | Whether multicast support is enabled | `bool` | `false` | no |
 | <a name="input_enable_sg_referencing_support"></a> [enable\_sg\_referencing\_support](#input\_enable\_sg\_referencing\_support) | Indicates whether to enable security group referencing support | `bool` | `true` | no |
 | <a name="input_enable_vpn_ecmp_support"></a> [enable\_vpn\_ecmp\_support](#input\_enable\_vpn\_ecmp\_support) | Whether VPN Equal Cost Multipath Protocol support is enabled | `bool` | `true` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -41,6 +41,9 @@ module "tgw" {
   # When "true", allows service discovery through IGMP
   enable_multicast_support = false
 
+  # When "true", enforces encryption-in-transit for traffic between VPCs attached to a Transit Gateway
+  enable_encryption_support = false
+
   vpc_attachments = {
     vpc1 = {
       vpc_id                             = module.vpc1.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ resource "aws_ec2_transit_gateway" "this" {
   dns_support                        = var.enable_dns_support ? "enable" : "disable"
   transit_gateway_cidr_blocks        = var.transit_gateway_cidr_blocks
   security_group_referencing_support = var.enable_sg_referencing_support ? "enable" : "disable"
+  encryption_support                 = var.enable_encryption_support ? "enable" : "disable"
 
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,12 @@ variable "enable_dns_support" {
   default     = true
 }
 
+variable "enable_encryption_support" {
+  description = "Should be true to enable encryption support in the TGW"
+  type        = bool
+  default     = false
+}
+
 variable "transit_gateway_cidr_blocks" {
   description = "One or more IPv4 or IPv6 CIDR blocks for the transit gateway. Must be a size /24 CIDR block or larger for IPv4, or a size /64 CIDR block or larger for IPv6"
   type        = list(string)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds `enable_encryption_support` variable to control the encryption of the created TGW (defaults to `false`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows the encryption support argument added to the AWS provider (https://github.com/hashicorp/terraform-provider-aws/pull/45317) to be utilized by this module 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
